### PR TITLE
fix(config): 抑制第三方库的 INFO 日志输出

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -349,6 +349,10 @@ if current_level != final_log_level:
 else:
     logger.info(f"当前日志级别: {logging.getLevelName(current_level)}")
 
+# 抑制第三方库的 INFO 日志输出（与 QA Bot 保持一致）
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("apscheduler").setLevel(logging.WARNING)
+
 # 机器人状态管理
 BOT_STATE_RUNNING = "running"
 BOT_STATE_PAUSED = "paused"


### PR DESCRIPTION
- 在日志配置完成后，添加对 httpx 和 apscheduler 库的日志级别设置
- 将这两个第三方库的日志级别调整为 WARNING，与 QA Bot 保持一致
- 避免在运行过程中产生过多的 INFO 级别日志，提升日志可读性

## Summary by Sourcery

错误修复：
- 将 `httpx` 和 `apscheduler` 的日志级别设置为 WARNING，以防止这些依赖项产生过多的 INFO 级别输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Set httpx and apscheduler loggers to WARNING to prevent excessive INFO-level output from these dependencies.

</details>