### PR TITLE
fix(database): 修复 MySQL 表已存在警告问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
     3. 使用 Python 的 `warnings.catch_warnings()` 上下文管理器过滤所有 Warning 类别的警告
     4. 将所有 CREATE TABLE 语句放在 `with warnings.catch_warnings():` 块内执行
     5. 在 `finally` 块中恢复原始的 sql_mode 设置
+    6. 使用参数化查询避免 SQL 注入风险
   - 影响：`core/database_mysql.py`
   - 修复效果：日志输出更清洁，不再显示表已存在的警告信息
   - 技术细节：
@@ -38,6 +39,7 @@
     - 使用 `try/finally` 确保 sql_mode 恢复的可靠性
     - 使用 `warnings.filterwarnings("ignore", category=Warning)` 过滤警告
     - 避免硬编码 sql_mode 值，确保兼容不同 MySQL 版本的默认配置
+    - 使用参数化查询 `SET SESSION sql_mode = %s` 替代字符串拼接，通过安全审计工具检查
 
 ### 新增
 - **频道评论区欢迎配置系统**：实现可配置的评论区欢迎消息功能，支持频道级自定义配置和默认配置

--- a/core/database_mysql.py
+++ b/core/database_mysql.py
@@ -273,11 +273,12 @@ class MySQLManager(DatabaseManagerBase):
 
         finally:
             # 恢复原始的 sql_mode 设置，确保即使建表失败也能恢复
+            # 使用参数化查询避免 SQL 注入风险
             if original_sql_mode:
-                await cursor.execute(f"SET SESSION sql_mode = '{original_sql_mode}'")
+                await cursor.execute("SET SESSION sql_mode = %s", (original_sql_mode,))
             else:
                 # 如果原始值为空，恢复到空字符串
-                await cursor.execute("SET SESSION sql_mode = ''")
+                await cursor.execute("SET SESSION sql_mode = %s", ("",))
 
     async def save_summary(
         self,


### PR DESCRIPTION
- 修复数据库初始化时显示大量 "Table already exists" 警告的问题
- 在 `_create_tables()` 方法中临时禁用 sql_mode，避免 MySQL 在表已存在时触发警告
- 表创建完成后恢复默认的严格模式 sql_mode 设置
- 修改文件：`core/database_mysql.py`
- 更新日志：`CHANGELOG.md` 中记录了此次修复

## 由 Sourcery 生成的总结

通过在创建数据表期间调整会话 SQL 模式，修复 MySQL 数据库初始化时的警告。

错误修复：
- 在 MySQL 数据库初始化过程中创建数据表时，临时禁用严格的 `sql_mode`，以抑制多余的“Table already exists”（数据表已存在）警告。

文档：
- 在更新日志中记录 MySQL 数据表已存在警告修复及其影响。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在初始化数据库时抑制 MySQL “表已存在” 警告，同时保留原始会话 SQL 模式，并在变更日志中记录此修复。

Bug Fixes:
- 在初始化 MySQL 数据库架构时，通过调整会话 SQL 模式并在建表过程中过滤驱动程序警告，防止出现过多的 “Table already exists” 警告。

Documentation:
- 在变更日志中记录 MySQL 表已存在警告修复及其行为变化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Suppress MySQL table-exists warnings during database initialization while preserving the original session SQL mode and document the fix in the changelog.

Bug Fixes:
- Prevent excessive "Table already exists" warnings when initializing the MySQL database schema by adjusting session SQL mode and filtering driver warnings during table creation.

Documentation:
- Document the MySQL table-exists warning fix and its behavior changes in the changelog.

</details>

</details>