### PR TITLE
fix(ci): 修复发布流程中附件状态检查逻辑，确保每次PR合并都上传最新附件

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -449,7 +449,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: 检查 Release 附件状态
+      - name: 检查并清理 Release 附件状态
         id: check_assets
         run: |
           TAG_NAME="${{ steps.get_version.outputs.TAG_NAME }}"
@@ -458,15 +458,25 @@ jobs:
           ASSETS=$(gh release view "$TAG_NAME" --json assets -q '.assets | length')
           echo "现有附件数量: $ASSETS"
           
-          if [ "$ASSETS" -eq 0 ]; then
-            echo "ℹ️ Release 没有附件，将添加附件"
-            echo "should_upload=true" >> $GITHUB_OUTPUT
-            echo "has_assets=false" >> $GITHUB_OUTPUT
+          if [ "$ASSETS" -gt 0 ]; then
+            echo "🗑️ 检测到已有附件，正在清理旧附件..."
+            
+            # 获取所有附件名称并删除
+            ASSET_NAMES=$(gh release view "$TAG_NAME" --json assets -q '.assets[].name')
+            for asset in $ASSET_NAMES; do
+              echo "  删除附件: $asset"
+              gh release delete-asset "$TAG_NAME" "$asset" -y
+            done
+            
+            echo "✅ 已删除 $ASSETS 个旧附件"
           else
-            echo "ℹ️ Release 已有附件，将跳过上传"
-            echo "should_upload=false" >> $GITHUB_OUTPUT
-            echo "has_assets=true" >> $GITHUB_OUTPUT
+            echo "ℹ️ Release 没有附件"
           fi
+          
+          # 无论是否有旧附件，都标记为需要上传（确保附件与代码同步）
+          echo "should_upload=true" >> $GITHUB_OUTPUT
+          echo "has_assets=false" >> $GITHUB_OUTPUT
+          echo "ℹ️ 将上传新的发布附件"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       


### PR DESCRIPTION
- 优化 Release 附件检查逻辑，当检测到已有附件时自动清理旧附件
- 统一设置 should_upload=true，确保每次PR合并都上传最新构建产物
- 移除基于附件存在状态的跳过逻辑，保证附件与代码版本同步
- 添加清理过程的日志输出，提高CI流程的可观察性

## Summary by Sourcery

CI：
- 更新 release-on-pr-merge 工作流，以删除现有的发布资源、始终将上传标记为必需，并为清理和上传步骤添加日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update release-on-pr-merge workflow to delete existing release assets, always mark uploads as required, and add logs for the cleanup and upload steps.

</details>