### PR TITLE
ci(release): 修复提交类型映射检查逻辑

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -179,7 +179,8 @@ jobs:
           esac
           
           # 确保 CHANGE_TYPE_LOWER 在 TYPE_MAP 中，否则默认为 chore
-          if [[ -z "${TYPE_MAP[$CHANGE_TYPE_LOWER]}" ]]; then
+          temp_value="${TYPE_MAP[$CHANGE_TYPE_LOWER]}"
+          if [[ -z "$temp_value" ]]; then
             CHANGE_TYPE_LOWER="chore"
           fi
           
@@ -201,7 +202,8 @@ jobs:
               if [[ "$commit" =~ ^([a-zA-Z]+)(\([^)]+\))?!: ]]; then
                 commit_type="${BASH_REMATCH[1],,}"  # 转换为小写
                 # 检查是否是已知类型
-                if [[ -n "${TYPE_MAP[$commit_type]}" ]]; then
+                temp_value="${TYPE_MAP[$commit_type]}"
+                if [[ -n "$temp_value" ]]; then
                   # 将提交添加到对应类型组
                   TYPE_COMMITS[$commit_type]="${TYPE_COMMITS[$commit_type]}$commit"$'\n'
                 else
@@ -211,7 +213,8 @@ jobs:
               elif [[ "$commit" =~ ^([a-zA-Z]+)(\([^)]+\))?: ]]; then
                 commit_type="${BASH_REMATCH[1],,}"  # 转换为小写
                 # 检查是否是已知类型
-                if [[ -n "${TYPE_MAP[$commit_type]}" ]]; then
+                temp_value="${TYPE_MAP[$commit_type]}"
+                if [[ -n "$temp_value" ]]; then
                   # 将提交添加到对应类型组
                   TYPE_COMMITS[$commit_type]="${TYPE_COMMITS[$commit_type]}$commit"$'\n'
                 else
@@ -228,14 +231,16 @@ jobs:
           # 添加 PR 标题到对应的类型组（支持重大变更标记 ! 和大小写混合）
           if [[ "$TITLE" =~ ^([a-zA-Z]+)(\([^)]+\))?!: ]]; then
             pr_type="${BASH_REMATCH[1],,}"  # 转换为小写
-            if [[ -n "${TYPE_MAP[$pr_type]}" ]]; then
+            temp_value="${TYPE_MAP[$pr_type]}"
+            if [[ -n "$temp_value" ]]; then
               TYPE_COMMITS[$pr_type]="- **${TITLE}** (PR #${PR_NUM})"$'\n'"${TYPE_COMMITS[$pr_type]}"
             else
               TYPE_COMMITS["chore"]="- **${TITLE}** (PR #${PR_NUM})"$'\n'"${TYPE_COMMITS["chore"]}"
             fi
           elif [[ "$TITLE" =~ ^([a-zA-Z]+)(\([^)]+\))?: ]]; then
             pr_type="${BASH_REMATCH[1],,}"  # 转换为小写
-            if [[ -n "${TYPE_MAP[$pr_type]}" ]]; then
+            temp_value="${TYPE_MAP[$pr_type]}"
+            if [[ -n "$temp_value" ]]; then
               TYPE_COMMITS[$pr_type]="- **${TITLE}** (PR #${PR_NUM})"$'\n'"${TYPE_COMMITS[$pr_type]}"
             else
               TYPE_COMMITS["chore"]="- **${TITLE}** (PR #${PR_NUM})"$'\n'"${TYPE_COMMITS["chore"]}"

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -14,4 +14,4 @@
 Sakura-Bot - 核心模块
 """
 
-__version__ = "1.6.6"
+__version__ = "1.6.7"

--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ from core.settings import (
 )
 
 # 版本信息
-__version__ = "1.6.6"
+__version__ = "1.6.7"
 
 from core.command_handlers.database_migration_commands import (
     handle_db_clear,


### PR DESCRIPTION
- 将直接访问关联数组的检查改为使用临时变量，避免在 bash 中直接检查关联数组元素是否为空导致的错误
- 确保在各种提交类型检查和 PR 标题处理中都能正确处理类型映射关系

chore(version): 更新版本号至 1.6.7

- 在 core/__init__.py 中更新版本号
- 在 main.py 中更新版本号

## Summary by Sourcery

修复发布工作流中提交类型映射的处理方式，并提升项目版本。

Build:
- 在整个代码库中将应用版本提升到 1.6.7。

CI:
- 修正 `release-on-pr-merge` 工作流中的提交类型映射检查，以在解析提交记录和 PR 标题时，能稳健地处理未知或未映射的类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix release workflow commit-type mapping handling and bump project version.

Build:
- Bump the application version to 1.6.7 across the codebase.

CI:
- Correct commit type mapping checks in the release-on-pr-merge workflow to robustly handle unknown or unmapped types when parsing commits and PR titles.

</details>