### PR TITLE
refactor(docs): 重命名并移动查询改写文档至wiki目录

### DIFF
--- a/wiki/Developer-Query-Rewrite-Enhancement.md
+++ b/wiki/Developer-Query-Rewrite-Enhancement.md
@@ -161,9 +161,9 @@ print(stats)
 
 ## 📚 相关文档
 
-- [RAG架构说明](wiki/Developer-RAG-Feature-V3.md)
-- [问答Bot使用指南](wiki/User-QA-Bot-Guide.md)
-- [多轮对话功能](wiki/User-Multi-Turn-Conversation.md)
+- [RAG架构说明](Developer-RAG-Feature-V3.md)
+- [问答Bot使用指南](User-QA-Bot-Guide.md)
+- [多轮对话功能](User-Multi-Turn-Conversation.md)
 
 ## 🔮 未来计划
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -29,6 +29,7 @@
 - **[错误处理增强](Developer-Error-Handling-Improvements.md)** - 错误处理机制
 - **[问答 Bot 实施](Developer-QA-Bot-Implementation.md)** - AI 功能实施文档
 - **[RAG 技术文档](Developer-RAG-Feature-V3.md)** - RAG 技术实现
+- **[查询改写增强](Developer-Query-Rewrite-Enhancement.md)** - QA 引擎查询改写功能说明
 - **[Ruff 脚本指南](Developer-Ruff-Script-Guide.md)** - 代码质量工具
 - **[CI/CD 工作流](Developer-Workflow-Improvements.md)** - 持续集成配置
 


### PR DESCRIPTION
- 将 docs/Query-Rewrite-Enhancement.md 重命名为 wiki/Developer-Query-Rewrite-Enhancement.md
- 更新文档内部的相对链接路径，移除冗余的wiki/前缀
- 在 wiki/Home.md 中添加查询改写增强文档的导航链接