### PR TITLE
为工具和问答引擎添加帖子链接支持

### DIFF
--- a/core/ai/agent_tools.py
+++ b/core/ai/agent_tools.py
@@ -16,6 +16,7 @@ Agentic RAG 工具定义与执行器
 import asyncio
 import json
 import logging
+import re
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -393,10 +394,12 @@ class ToolExecutor:
             normalized = {
                 "summary_id": sid,
                 "summary_text": r.get("summary_text", ""),
+                "post_links": self._build_summary_post_links(r),
                 "metadata": {
                     "channel_id": r.get("channel_id"),
                     "channel_name": r.get("channel_name"),
                     "created_at": r.get("created_at"),
+                    "post_links": self._build_summary_post_links(r),
                 },
             }
             self._store_result(normalized)
@@ -472,10 +475,12 @@ class ToolExecutor:
             normalized = {
                 "summary_id": sid,
                 "summary_text": r.get("summary_text", ""),
+                "post_links": self._build_summary_post_links(r),
                 "metadata": {
                     "channel_id": r.get("channel_id"),
                     "channel_name": r.get("channel_name"),
                     "created_at": r.get("created_at"),
+                    "post_links": self._build_summary_post_links(r),
                 },
                 "source": "summary",
             }
@@ -546,6 +551,7 @@ class ToolExecutor:
             "created_at": created_at,
             "doc_id": result.get("doc_id"),
             "source": result.get("source"),
+            "post_links": ToolExecutor._get_post_links(result),
         }
         if "similarity" in result:
             serialized["similarity"] = round(result["similarity"], 3)
@@ -561,6 +567,71 @@ class ToolExecutor:
         doc_id = result.get("doc_id")
         if doc_id:
             self._doc_result_store[str(doc_id)] = result
+
+    @staticmethod
+    def _build_summary_post_links(summary: dict[str, Any], max_links: int = 5) -> list[str]:
+        """根据总结中的消息 ID 构造 Telegram 帖子链接。"""
+        channel_id = summary.get("channel_id") or summary.get("metadata", {}).get("channel_id")
+        metadata = summary.get("metadata", {})
+        message_ids = (
+            summary.get("summary_message_ids") or metadata.get("summary_message_ids") or []
+        )
+        if isinstance(message_ids, str):
+            try:
+                message_ids = json.loads(message_ids)
+            except json.JSONDecodeError:
+                message_ids = []
+
+        return [
+            link
+            for message_id in message_ids[:max_links]
+            if (link := ToolExecutor._build_post_link(channel_id, message_id))
+        ]
+
+    @staticmethod
+    def _get_post_links(result: dict[str, Any]) -> list[str]:
+        """从结果中提取或构造帖子链接。"""
+        metadata = result.get("metadata", {})
+        links = result.get("post_links") or metadata.get("post_links") or []
+        if isinstance(links, str):
+            try:
+                links = json.loads(links)
+            except json.JSONDecodeError:
+                links = [links]
+        if links:
+            return links
+
+        summary_links = ToolExecutor._build_summary_post_links(result)
+        if summary_links:
+            return summary_links
+
+        doc_id = result.get("doc_id")
+        channel_id = metadata.get("channel_id") or result.get("channel_id")
+        message_id = metadata.get("message_id") or result.get("message_id")
+
+        if not message_id and doc_id:
+            match = re.search(r":(\d+)$", str(doc_id))
+            if match:
+                message_id = match.group(1)
+
+        link = ToolExecutor._build_post_link(channel_id, message_id)
+        return [link] if link else []
+
+    @staticmethod
+    def _build_post_link(channel_id: str | None, message_id: Any) -> str | None:
+        """构造 Telegram 公开频道帖子链接。"""
+        if not channel_id or not message_id:
+            return None
+
+        channel = str(channel_id).strip().rstrip("/")
+        if "/+" in channel or channel.split("/")[-1].startswith("+"):
+            return None
+
+        channel_part = channel.split("/")[-1].lstrip("@")
+        if not channel_part or not str(message_id).isdigit():
+            return None
+
+        return f"https://t.me/{channel_part}/{message_id}"
 
     def get_all_results(self) -> list[dict[str, Any]]:
         """获取所有累积的搜索结果（完整文本，不截断）。"""

--- a/core/ai/agent_tools.py
+++ b/core/ai/agent_tools.py
@@ -77,7 +77,7 @@ TOOL_SCHEMAS = [
             "description": (
                 "基于关键词搜索频道历史总结。"
                 "使用SQL匹配，适合精确关键词查找和补充语义检索的结果。"
-                "当语义搜索结果不足或需要查找特定术语时使用。"
+                "当语义搜索结果不足、需要查找特定术语，或需要按频道/时间获取最近总结时使用。"
             ),
             "parameters": {
                 "type": "object",
@@ -107,7 +107,106 @@ TOOL_SCHEMAS = [
                         "default": 10,
                     },
                 },
-                "required": ["keywords"],
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_channels",
+            "description": "获取所有可查询频道的名称、链接、总结数和最后更新时间。用户询问频道链接、有哪些频道、可查询范围时使用。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "返回频道数量上限，默认50",
+                        "default": 50,
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "resolve_channel",
+            "description": "根据频道名、@username、t.me链接或模糊名称解析为标准频道链接。限定频道查询前应先调用。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "channel_hint": {
+                        "type": "string",
+                        "description": "用户提到的频道名称、@username 或 Telegram 链接",
+                    },
+                },
+                "required": ["channel_hint"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_recent_summaries",
+            "description": "获取指定频道或所有频道的最近总结，适合回答最近发生了什么、最新动态等问题。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "channel_id": {
+                        "type": "string",
+                        "description": "可选，限定频道链接。若用户给的是频道名，应先调用 resolve_channel。",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "返回总结数量，默认5",
+                        "default": 5,
+                    },
+                    "time_range_days": {
+                        "type": "integer",
+                        "description": "可选，最近N天",
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_channel_stats",
+            "description": "获取指定频道的总结数量、消息数量和更新时间等统计信息。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "channel_id": {
+                        "type": "string",
+                        "description": "标准频道链接。若用户给的是频道名，应先调用 resolve_channel。",
+                    },
+                },
+                "required": ["channel_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_source_detail",
+            "description": "按 summary_id 或 doc_id 获取之前搜索结果中的完整来源内容。用户要求展开来源、查看详情时使用。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "summary_id": {
+                        "type": "integer",
+                        "description": "搜索结果中的 summary_id",
+                    },
+                    "doc_id": {
+                        "type": "string",
+                        "description": "搜索结果中的原始 doc_id，适用于消息向量来源",
+                    },
+                },
+                "required": [],
             },
         },
     },
@@ -176,10 +275,12 @@ class ToolExecutor:
         self.reranker = reranker
         # 累积所有搜索结果，供 rerank_results 按 ID 引用
         self._result_store: dict[int, dict[str, Any]] = {}
+        self._doc_result_store: dict[str, dict[str, Any]] = {}
 
     def reset(self):
         """重置结果存储（每次 agent loop 开始时调用）"""
         self._result_store.clear()
+        self._doc_result_store.clear()
 
     async def execute(self, tool_name: str, arguments: dict[str, Any]) -> str:
         """执行工具调用，返回 JSON 字符串格式的结果。
@@ -193,6 +294,16 @@ class ToolExecutor:
                 return await self._execute_keyword_search(arguments)
             elif tool_name == "rerank_results":
                 return await self._execute_rerank(arguments)
+            elif tool_name == "list_channels":
+                return await self._execute_list_channels(arguments)
+            elif tool_name == "resolve_channel":
+                return await self._execute_resolve_channel(arguments)
+            elif tool_name == "get_recent_summaries":
+                return await self._execute_recent_summaries(arguments)
+            elif tool_name == "get_channel_stats":
+                return await self._execute_channel_stats(arguments)
+            elif tool_name == "get_source_detail":
+                return await self._execute_source_detail(arguments)
             elif tool_name == "get_channel_info":
                 return await self._execute_channel_info(arguments)
             else:
@@ -256,8 +367,7 @@ class ToolExecutor:
         # 累积到 result_store 并序列化（截断长文本）
         serialized = []
         for r in results:
-            sid = r["summary_id"]
-            self._result_store[sid] = r
+            self._store_result(r)
             serialized.append(self._serialize_result(r))
 
         return json.dumps(
@@ -289,7 +399,7 @@ class ToolExecutor:
                     "created_at": r.get("created_at"),
                 },
             }
-            self._result_store[sid] = normalized
+            self._store_result(normalized)
             serialized.append(self._serialize_result(normalized))
 
         return json.dumps(
@@ -324,9 +434,7 @@ class ToolExecutor:
         # 更新 result_store 中的结果（含 rerank_score）
         serialized = []
         for r in reranked:
-            sid = r.get("summary_id")
-            if sid is not None:
-                self._result_store[sid] = r
+            self._store_result(r)
             serialized.append(self._serialize_result(r))
 
         return json.dumps(
@@ -334,8 +442,79 @@ class ToolExecutor:
             ensure_ascii=False,
         )
 
+    async def _execute_list_channels(self, args: dict) -> str:
+        channels = await self.memory_manager.list_channels()
+        limit = max(1, min(int(args.get("limit", 50)), 100))
+        return json.dumps(
+            {
+                "channels": channels[:limit],
+                "count": min(len(channels), limit),
+                "total": len(channels),
+            },
+            ensure_ascii=False,
+        )
+
+    async def _execute_resolve_channel(self, args: dict) -> str:
+        result = await self.memory_manager.resolve_channel(args.get("channel_hint", ""))
+        return json.dumps(result, ensure_ascii=False)
+
+    async def _execute_recent_summaries(self, args: dict) -> str:
+        results = await self.memory_manager.get_recent_summaries(
+            channel_id=args.get("channel_id"),
+            limit=args.get("limit", 5),
+            time_range_days=args.get("time_range_days"),
+        )
+        serialized = []
+        for r in results:
+            sid = r.get("id") or r.get("summary_id")
+            if sid is None:
+                continue
+            normalized = {
+                "summary_id": sid,
+                "summary_text": r.get("summary_text", ""),
+                "metadata": {
+                    "channel_id": r.get("channel_id"),
+                    "channel_name": r.get("channel_name"),
+                    "created_at": r.get("created_at"),
+                },
+                "source": "summary",
+            }
+            self._store_result(normalized)
+            serialized.append(self._serialize_result(normalized))
+
+        return json.dumps({"results": serialized, "count": len(serialized)}, ensure_ascii=False)
+
+    async def _execute_channel_stats(self, args: dict) -> str:
+        stats = await self.memory_manager.get_channel_stats(args.get("channel_id", ""))
+        return json.dumps({"stats": stats}, ensure_ascii=False)
+
+    async def _execute_source_detail(self, args: dict) -> str:
+        result = None
+        summary_id = args.get("summary_id")
+        doc_id = args.get("doc_id")
+
+        if summary_id is not None:
+            result = self._result_store.get(summary_id)
+
+        if result is None and doc_id:
+            result = self._doc_result_store.get(str(doc_id))
+
+        if result is None:
+            return json.dumps(
+                {"error": "未找到来源详情，请先执行搜索或提供有效的 summary_id/doc_id"},
+                ensure_ascii=False,
+            )
+
+        detail = self._serialize_result(result)
+        detail["summary_text"] = result.get("summary_text", "")
+        return json.dumps({"detail": detail}, ensure_ascii=False)
+
     async def _execute_channel_info(self, args: dict) -> str:
         channel_id = args.get("channel_id")
+        if not channel_id:
+            channels = await self.memory_manager.list_channels()
+            return json.dumps({"channels": channels, "count": len(channels)}, ensure_ascii=False)
+
         context = await self.memory_manager.get_channel_context(channel_id)
 
         if channel_id:
@@ -362,14 +541,26 @@ class ToolExecutor:
         serialized = {
             "summary_id": result.get("summary_id"),
             "summary_text": truncated,
+            "channel_id": metadata.get("channel_id"),
             "channel_name": metadata.get("channel_name"),
             "created_at": created_at,
+            "doc_id": result.get("doc_id"),
+            "source": result.get("source"),
         }
         if "similarity" in result:
             serialized["similarity"] = round(result["similarity"], 3)
         if "rerank_score" in result:
             serialized["rerank_score"] = round(result["rerank_score"], 3)
         return serialized
+
+    def _store_result(self, result: dict[str, Any]) -> None:
+        """缓存搜索结果，供重排序和来源详情工具复用。"""
+        sid = result.get("summary_id")
+        if sid is not None:
+            self._result_store[sid] = result
+        doc_id = result.get("doc_id")
+        if doc_id:
+            self._doc_result_store[str(doc_id)] = result
 
     def get_all_results(self) -> list[dict[str, Any]]:
         """获取所有累积的搜索结果（完整文本，不截断）。"""

--- a/core/ai/agent_tools.py
+++ b/core/ai/agent_tools.py
@@ -79,6 +79,7 @@ TOOL_SCHEMAS = [
                 "基于关键词搜索频道历史总结。"
                 "使用SQL匹配，适合精确关键词查找和补充语义检索的结果。"
                 "当语义搜索结果不足、需要查找特定术语，或需要按频道/时间获取最近总结时使用。"
+                "keywords 可为空；为空时将按 channel_id/time_range_days/limit 做频道或时间过滤。"
             ),
             "parameters": {
                 "type": "object",
@@ -391,15 +392,16 @@ class ToolExecutor:
             sid = r.get("id")
             if sid is None:
                 continue
+            post_links = self._build_summary_post_links(r)
             normalized = {
                 "summary_id": sid,
                 "summary_text": r.get("summary_text", ""),
-                "post_links": self._build_summary_post_links(r),
+                "post_links": post_links,
                 "metadata": {
                     "channel_id": r.get("channel_id"),
                     "channel_name": r.get("channel_name"),
                     "created_at": r.get("created_at"),
-                    "post_links": self._build_summary_post_links(r),
+                    "post_links": post_links,
                 },
             }
             self._store_result(normalized)
@@ -472,15 +474,16 @@ class ToolExecutor:
             sid = r.get("id") or r.get("summary_id")
             if sid is None:
                 continue
+            post_links = self._build_summary_post_links(r)
             normalized = {
                 "summary_id": sid,
                 "summary_text": r.get("summary_text", ""),
-                "post_links": self._build_summary_post_links(r),
+                "post_links": post_links,
                 "metadata": {
                     "channel_id": r.get("channel_id"),
                     "channel_name": r.get("channel_name"),
                     "created_at": r.get("created_at"),
-                    "post_links": self._build_summary_post_links(r),
+                    "post_links": post_links,
                 },
                 "source": "summary",
             }
@@ -635,7 +638,13 @@ class ToolExecutor:
 
     def get_all_results(self) -> list[dict[str, Any]]:
         """获取所有累积的搜索结果（完整文本，不截断）。"""
-        return list(self._result_store.values())
+        all_results = list(self._result_store.values())
+        seen_ids = {id(result) for result in all_results}
+        for result in self._doc_result_store.values():
+            if id(result) not in seen_ids:
+                all_results.append(result)
+                seen_ids.add(id(result))
+        return all_results
 
     def get_results_by_ids(self, ids: list[int]) -> list[dict[str, Any]]:
         """根据 ID 列表获取结果，按 ID 出现顺序排列。"""

--- a/core/ai/agent_tools.py
+++ b/core/ai/agent_tools.py
@@ -638,12 +638,13 @@ class ToolExecutor:
 
     def get_all_results(self) -> list[dict[str, Any]]:
         """获取所有累积的搜索结果（完整文本，不截断）。"""
-        all_results = list(self._result_store.values())
-        seen_ids = {id(result) for result in all_results}
-        for result in self._doc_result_store.values():
-            if id(result) not in seen_ids:
+        all_results = []
+        seen_keys = set()
+        for result in [*self._result_store.values(), *self._doc_result_store.values()]:
+            key = (result.get("summary_id"), result.get("doc_id"))
+            if key not in seen_keys:
                 all_results.append(result)
-                seen_ids.add(id(result))
+                seen_keys.add(key)
         return all_results
 
     def get_results_by_ids(self, ids: list[int]) -> list[dict[str, Any]]:

--- a/core/ai/intent_parser.py
+++ b/core/ai/intent_parser.py
@@ -267,7 +267,7 @@ class IntentParser:
         if link_match:
             return link_match.group(0).rstrip("。，,；;！!？?")
 
-        mention_match = re.search(r"@[A-Za-z0-9_]{4,}", query)
+        mention_match = re.search(r"@[A-Za-z0-9_]{5,}", query)
         if mention_match:
             return mention_match.group(0)
 

--- a/core/ai/intent_parser.py
+++ b/core/ai/intent_parser.py
@@ -183,6 +183,7 @@ class IntentParser:
                 "time_range": Optional[int],  # 时间范围（天数），None 表示不限制
                 "keywords": List[str], # 关键词
                 "channel_id": Optional[str],  # 频道ID
+                "channel_hint": Optional[str],  # 用户提到的频道提示
                 "original_query": str, # 原始查询
                 "confidence": float    # 置信度
             }
@@ -196,8 +197,14 @@ class IntentParser:
             "time_range": None,
             "keywords": [],
             "channel_id": None,
+            "channel_hint": None,
             "confidence": 0.0,
         }
+
+        channel_hint = self._extract_channel_hint(query)
+        if channel_hint:
+            result["channel_hint"] = channel_hint
+            logger.info(f"提取频道提示: {channel_hint}")
 
         # 1. 检测状态查询意图
         if self._is_status_query(query):
@@ -247,6 +254,34 @@ class IntentParser:
             # result["time_range"] 保持 None
 
         return result
+
+    def _extract_channel_hint(self, query: str) -> str | None:
+        """
+        提取查询中的频道提示。
+
+        支持 @username、Telegram 链接，以及“在 xxx 频道”这类自然语言片段。
+        """
+        link_match = re.search(
+            r"(?:https?://)?(?:www\.)?(?:t\.me|telegram\.me)/[A-Za-z0-9_+/-]+", query
+        )
+        if link_match:
+            return link_match.group(0).rstrip("。，,；;！!？?")
+
+        mention_match = re.search(r"@[A-Za-z0-9_]{4,}", query)
+        if mention_match:
+            return mention_match.group(0)
+
+        natural_patterns = [
+            r"在\s*([^，。！？?\s]{2,40})\s*频道",
+            r"从\s*([^，。！？?\s]{2,40})\s*频道",
+            r"查询\s*([^，。！？?\s]{2,40})\s*频道",
+        ]
+        for pattern in natural_patterns:
+            match = re.search(pattern, query)
+            if match:
+                return match.group(1).strip()
+
+        return None
 
     def _is_status_query(self, query: str) -> bool:
         """检查是否为状态查询"""

--- a/core/ai/memory_manager.py
+++ b/core/ai/memory_manager.py
@@ -14,10 +14,11 @@
 
 import json
 import logging
-from datetime import UTC
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from core.ai.ai_client import client_llm
+from core.config import normalize_channel_id
 from core.infrastructure.database import get_db_manager
 from core.settings import get_llm_model
 
@@ -178,6 +179,145 @@ class MemoryManager:
             logger.error(f"获取频道上下文失败: {type(e).__name__}: {e}", exc_info=True)
             return ""
 
+    async def list_channels(self) -> list[dict[str, Any]]:
+        """
+        获取所有可查询频道。
+
+        Returns:
+            频道列表，包含频道链接、名称、更新时间和统计信息
+        """
+        try:
+            channels = await self.db.get_all_channels()
+            return [self._normalize_channel_row(channel) for channel in channels]
+        except Exception as e:
+            logger.error(f"获取频道列表失败: {type(e).__name__}: {e}", exc_info=True)
+            return []
+
+    async def resolve_channel(self, channel_hint: str) -> dict[str, Any]:
+        """
+        将用户输入的频道提示解析为标准频道链接。
+
+        Args:
+            channel_hint: 频道链接、@username、频道名或链接尾段
+
+        Returns:
+            解析结果。唯一匹配时 success=True；多候选时返回 candidates。
+        """
+        try:
+            hint = (channel_hint or "").strip()
+            if not hint:
+                return {"success": False, "error": "频道提示为空", "candidates": []}
+
+            channels = await self.list_channels()
+            normalized_hint = normalize_channel_id(hint)
+            hint_lower = hint.lower().lstrip("@")
+            normalized_lower = normalized_hint.lower()
+
+            exact_matches = []
+            fuzzy_matches = []
+
+            for channel in channels:
+                channel_id = channel.get("channel_id", "")
+                channel_name = channel.get("channel_name", "") or ""
+                channel_tail = channel_id.rstrip("/").split("/")[-1]
+                candidates = {
+                    channel_id.lower(),
+                    normalize_channel_id(channel_id).lower(),
+                    channel_tail.lower(),
+                    channel_name.lower(),
+                }
+
+                if normalized_lower in candidates or hint_lower in candidates:
+                    exact_matches.append(channel)
+                    continue
+
+                if hint_lower in channel_name.lower() or hint_lower in channel_tail.lower():
+                    fuzzy_matches.append(channel)
+
+            matches = exact_matches or fuzzy_matches
+            if len(matches) == 1:
+                match = matches[0]
+                return {
+                    "success": True,
+                    "channel_id": match.get("channel_id"),
+                    "channel_name": match.get("channel_name"),
+                    "match_type": "exact" if exact_matches else "fuzzy",
+                    "channel": match,
+                }
+
+            if len(matches) > 1:
+                return {
+                    "success": False,
+                    "error": "找到多个匹配频道，请提供更完整的频道链接或名称",
+                    "candidates": matches[:10],
+                }
+
+            # 没有目录匹配时，若输入看起来像 Telegram 标识，返回标准化链接供后续检索尝试。
+            if hint.startswith(("@", "http://", "https://", "t.me/", "telegram.me/")):
+                return {
+                    "success": True,
+                    "channel_id": normalized_hint,
+                    "channel_name": normalized_hint.split("/")[-1],
+                    "match_type": "normalized",
+                    "channel": {
+                        "channel_id": normalized_hint,
+                        "channel_name": normalized_hint.split("/")[-1],
+                    },
+                }
+
+            return {"success": False, "error": "未找到匹配频道", "candidates": []}
+
+        except Exception as e:
+            logger.error(f"解析频道失败: {type(e).__name__}: {e}", exc_info=True)
+            return {"success": False, "error": f"解析频道失败: {e}", "candidates": []}
+
+    async def get_channel_stats(self, channel_id: str) -> dict[str, Any]:
+        """
+        获取频道统计信息。
+
+        Args:
+            channel_id: 标准频道链接
+
+        Returns:
+            频道统计字典
+        """
+        try:
+            stats = await self.db.get_channel_summary_stats(channel_id)
+            return self._normalize_channel_row(stats) if stats else {}
+        except Exception as e:
+            logger.error(f"获取频道统计失败: {type(e).__name__}: {e}", exc_info=True)
+            return {}
+
+    async def get_recent_summaries(
+        self,
+        channel_id: str | None = None,
+        limit: int = 5,
+        time_range_days: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        获取最近总结。
+
+        Args:
+            channel_id: 可选频道链接
+            limit: 返回数量
+            time_range_days: 可选时间范围
+
+        Returns:
+            最近总结列表
+        """
+        try:
+            end_date = datetime.now(UTC)
+            start_date = end_date - timedelta(days=time_range_days) if time_range_days else None
+            return await self.db.get_recent_summaries(
+                channel_id=channel_id,
+                limit=limit,
+                start_date=start_date,
+                end_date=end_date if time_range_days else None,
+            )
+        except Exception as e:
+            logger.error(f"获取最近总结失败: {type(e).__name__}: {e}", exc_info=True)
+            return []
+
     async def search_summaries(
         self,
         keywords: list[str] = None,
@@ -185,6 +325,7 @@ class MemoryManager:
         time_range_days: int = 7,
         channel_id: str | None = None,
         limit: int = 10,
+        date_before: datetime | None = None,
     ) -> list[dict[str, Any]]:
         """
         搜索相关总结
@@ -203,7 +344,7 @@ class MemoryManager:
             from datetime import datetime, timedelta
 
             # 计算时间范围
-            end_date = datetime.now(UTC)
+            end_date = date_before or datetime.now(UTC)
             start_date = end_date - timedelta(days=time_range_days)
 
             # 获取基础总结
@@ -261,6 +402,18 @@ class MemoryManager:
         except Exception as e:
             logger.error(f"搜索总结失败: {type(e).__name__}: {e}", exc_info=True)
             return []
+
+    @staticmethod
+    def _normalize_channel_row(channel: dict[str, Any]) -> dict[str, Any]:
+        """标准化频道行中的日期和数值字段。"""
+        normalized = dict(channel or {})
+        for field in ("last_summary_time", "first_summary_time"):
+            value = normalized.get(field)
+            if hasattr(value, "isoformat"):
+                normalized[field] = value.isoformat()
+        normalized["summary_count"] = int(normalized.get("summary_count") or 0)
+        normalized["message_count"] = int(normalized.get("message_count") or 0)
+        return normalized
 
 
 # 创建全局记忆管理器实例

--- a/core/ai/memory_manager.py
+++ b/core/ai/memory_manager.py
@@ -212,6 +212,7 @@ class MemoryManager:
             normalized_hint = normalize_channel_id(hint)
             hint_lower = hint.lower().lstrip("@")
             normalized_lower = normalized_hint.lower()
+            hint_tail_lower = normalized_hint.rstrip("/").split("/")[-1].lower().lstrip("@")
 
             exact_matches = []
             fuzzy_matches = []
@@ -227,11 +228,19 @@ class MemoryManager:
                     channel_name.lower(),
                 }
 
-                if normalized_lower in candidates or hint_lower in candidates:
+                if (
+                    normalized_lower in candidates
+                    or hint_lower in candidates
+                    or hint_tail_lower in candidates
+                ):
                     exact_matches.append(channel)
                     continue
 
-                if hint_lower in channel_name.lower() or hint_lower in channel_tail.lower():
+                if (
+                    hint_lower in channel_name.lower()
+                    or hint_lower in channel_tail.lower()
+                    or hint_tail_lower in channel_tail.lower()
+                ):
                     fuzzy_matches.append(channel)
 
             matches = exact_matches or fuzzy_matches
@@ -300,7 +309,7 @@ class MemoryManager:
         Args:
             channel_id: 可选频道链接
             limit: 返回数量
-            time_range_days: 可选时间范围
+            time_range_days: 可选时间范围；不传时返回不限时间范围的最近 N 条
 
         Returns:
             最近总结列表

--- a/core/ai/qa_engine_v3.py
+++ b/core/ai/qa_engine_v3.py
@@ -586,6 +586,7 @@ class QAEngineV3:
             time_range = parsed.get("time_range")
             # 这里预解析频道用于约束首轮检索与降级流水线；即使 agentic 模式后续
             # 自主调用 resolve_channel，也可以确保向量检索从一开始就限定频道。
+            # 预解析仅做快速限定；若无法唯一解析，agentic 工具仍可返回候选供 LLM 选择。
             channel_id = await self._resolve_channel_from_parsed(parsed)
 
             conversation_history = await self.conversation_mgr.get_conversation_history(
@@ -680,7 +681,7 @@ class QAEngineV3:
             channel_name = metadata.get("channel_name") or summary.get("channel_name", "未知频道")
             created_at = metadata.get("created_at") or summary.get("created_at", "")
             summary_text = summary.get("summary_text", "")
-            post_links = self._extract_post_links(summary)
+            post_links = QAEngineV3._extract_post_links(summary)
 
             # 来源标签（总结 or 原始消息）
             source_tag = ""
@@ -720,7 +721,7 @@ class QAEngineV3:
             metadata = s.get("metadata", {})
             channel_id = metadata.get("channel_id") or s.get("channel_id", "")
             channel_name = metadata.get("channel_name") or s.get("channel_name", "未知频道")
-            for link in self._extract_post_links(s):
+            for link in QAEngineV3._extract_post_links(s):
                 if link not in post_links:
                     post_links.append(link)
 

--- a/core/ai/qa_engine_v3.py
+++ b/core/ai/qa_engine_v3.py
@@ -71,13 +71,19 @@ AGENT_TOOL_INSTRUCTIONS = """
 - **semantic_search**: 语义搜索，适合模糊/概念性查询
 - **keyword_search**: 关键词搜索，适合精确匹配特定术语
 - **rerank_results**: 对搜索结果重排序（结果>5条时考虑使用）
-- **get_channel_info**: 获取频道信息
+- **list_channels**: 获取所有可查询频道链接
+- **resolve_channel**: 将频道名、@username 或链接解析为标准频道链接
+- **get_recent_summaries**: 获取最近总结，适合回答最新动态
+- **get_channel_stats**: 获取频道统计信息
+- **get_source_detail**: 展开之前搜索结果的完整来源内容
 
 ### 使用策略
 1. 分析用户问题，确定需要的搜索方式和参数
-2. 可以同时调用多个搜索工具（如语义+关键词并行检索）
-3. 评估搜索结果：结果充足则回答，不足则调整参数再次搜索
-4. 最多进行{max_iterations}轮工具调用
+2. 如果用户询问可用频道或频道链接，优先调用 list_channels
+3. 如果用户指定频道名、@username 或频道链接，先调用 resolve_channel，再把 channel_id 传给搜索工具
+4. 可以同时调用多个搜索工具（如语义+关键词并行检索）
+5. 评估搜索结果：结果充足则回答，不足则调整参数再次搜索
+6. 最多进行{max_iterations}轮工具调用
 """
 
 
@@ -199,6 +205,7 @@ class QAEngineV3:
             query = parsed["original_query"]
             keywords = parsed.get("keywords", [])
             time_range = parsed.get("time_range")  # 可能为 None
+            channel_id = await self._resolve_channel_from_parsed(parsed)
 
             # 获取对话历史
             conversation_history = await self.conversation_mgr.get_conversation_history(
@@ -220,12 +227,18 @@ class QAEngineV3:
                     # 优先使用双 collection 联合检索
                     if self.vector_store.is_messages_available():
                         semantic_results = self.vector_store.search_all(
-                            query=query, top_k=20, date_after=date_after
+                            query=query,
+                            top_k=20,
+                            filter_metadata={"channel_id": channel_id} if channel_id else None,
+                            date_after=date_after,
                         )
                         logger.info(f"双collection语义检索: 找到 {len(semantic_results)} 条结果")
                     else:
                         semantic_results = self.vector_store.search_similar(
-                            query=query, top_k=20, date_after=date_after
+                            query=query,
+                            top_k=20,
+                            filter_metadata={"channel_id": channel_id} if channel_id else None,
+                            date_after=date_after,
                         )
                         logger.info(f"语义检索(summaries): 找到 {len(semantic_results)} 条结果")
                 except Exception as e:
@@ -238,7 +251,10 @@ class QAEngineV3:
                 try:
                     search_days = time_range if time_range is not None else 90
                     keyword_results = await self.memory_manager.search_summaries(
-                        keywords=keywords, time_range_days=search_days, limit=10
+                        keywords=keywords,
+                        time_range_days=search_days,
+                        channel_id=channel_id,
+                        limit=10,
                     )
                     logger.info(f"关键词检索: 找到 {len(keyword_results)} 条结果")
                 except Exception as e:
@@ -512,7 +528,7 @@ class QAEngineV3:
             suffix = f"\n\n{source_info}"
             yield suffix
 
-    async def process_query_stream(self, query: str, user_id: int):
+    async def process_query_stream(self, query: str, user_id: int, channel_hint: str | None = None):
         """
         流式处理用户查询（异步生成器版本）
 
@@ -536,6 +552,8 @@ class QAEngineV3:
 
             # 3. 解析查询意图
             parsed = self.intent_parser.parse_query(query)
+            if channel_hint:
+                parsed["channel_hint"] = channel_hint
             intent = parsed["intent"]
 
             # 4. 非内容查询直接返回（不使用流式）
@@ -564,6 +582,7 @@ class QAEngineV3:
             original_query = parsed["original_query"]
             keywords = parsed.get("keywords", [])
             time_range = parsed.get("time_range")
+            channel_id = await self._resolve_channel_from_parsed(parsed)
 
             conversation_history = await self.conversation_mgr.get_conversation_history(
                 user_id, session_id
@@ -584,6 +603,8 @@ class QAEngineV3:
                     time_range=time_range,
                     date_after=date_after,
                     keywords=keywords,
+                    channel_id=channel_id,
+                    channel_hint=parsed.get("channel_hint"),
                 ):
                     full_answer += chunk
                     yield chunk
@@ -595,6 +616,7 @@ class QAEngineV3:
                     keywords=keywords,
                     time_range=time_range,
                     date_after=date_after,
+                    channel_id=channel_id,
                 )
                 if final_candidates:
                     async for chunk in self.generate_answer_stream(
@@ -696,6 +718,23 @@ class QAEngineV3:
 
         return f"📚 数据来源: {len(sources)}个频道\n" + "\n".join(sources)
 
+    async def _resolve_channel_from_parsed(self, parsed: dict[str, Any]) -> str | None:
+        """根据解析结果获取标准频道 ID。"""
+        channel_id = parsed.get("channel_id")
+        if channel_id:
+            return channel_id
+
+        channel_hint = parsed.get("channel_hint")
+        if not channel_hint:
+            return None
+
+        resolved = await self.memory_manager.resolve_channel(channel_hint)
+        if resolved.get("success"):
+            return resolved.get("channel_id")
+
+        logger.info(f"频道提示未能唯一解析: {channel_hint}, result={resolved}")
+        return None
+
     async def _agentic_stream(
         self,
         query: str,
@@ -703,6 +742,8 @@ class QAEngineV3:
         time_range: int | None,
         date_after: str | None,
         keywords: list[str],
+        channel_id: str | None = None,
+        channel_hint: str | None = None,
     ):
         """Agentic RAG 流式生成器。Tool-calling 循环（非流式）+ 最终回答（流式）。"""
         self.tool_executor.reset()
@@ -732,6 +773,11 @@ class QAEngineV3:
             intent_parts.append(f"系统分析的时间范围: 最近 {time_range} 天")
         if date_after:
             intent_parts.append(f"时间过滤起点: {date_after}")
+        if channel_hint:
+            intent_parts.append(f"用户指定的频道提示: {channel_hint}")
+        if channel_id:
+            intent_parts.append(f"已解析频道ID: {channel_id}")
+            intent_parts.append("后续检索必须优先带上该 channel_id 过滤。")
 
         intent_note = "\n".join(intent_parts) if intent_parts else ""
         user_content = query
@@ -848,6 +894,7 @@ class QAEngineV3:
         keywords: list[str],
         time_range: int | None,
         date_after: str | None,
+        channel_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """降级到固定流水线（当 Agentic 处理异常时使用）。"""
         logger.info("[fallback] 使用固定流水线检索")
@@ -857,7 +904,10 @@ class QAEngineV3:
         if self.vector_store.is_available():
             try:
                 semantic_results = self.vector_store.search_similar(
-                    query=search_query, top_k=20, date_after=date_after
+                    query=search_query,
+                    top_k=20,
+                    filter_metadata={"channel_id": channel_id} if channel_id else None,
+                    date_after=date_after,
                 )
             except Exception as e:
                 logger.error(f"[fallback] 语义检索失败: {e}")
@@ -868,7 +918,10 @@ class QAEngineV3:
             try:
                 search_days = time_range if time_range is not None else 90
                 keyword_results = await self.memory_manager.search_summaries(
-                    keywords=keywords, time_range_days=search_days, limit=10
+                    keywords=keywords,
+                    time_range_days=search_days,
+                    channel_id=channel_id,
+                    limit=10,
                 )
             except Exception as e:
                 logger.error(f"[fallback] 关键词检索失败: {e}")

--- a/core/ai/qa_engine_v3.py
+++ b/core/ai/qa_engine_v3.py
@@ -584,6 +584,8 @@ class QAEngineV3:
             original_query = parsed["original_query"]
             keywords = parsed.get("keywords", [])
             time_range = parsed.get("time_range")
+            # 这里预解析频道用于约束首轮检索与降级流水线；即使 agentic 模式后续
+            # 自主调用 resolve_channel，也可以确保向量检索从一开始就限定频道。
             channel_id = await self._resolve_channel_from_parsed(parsed)
 
             conversation_history = await self.conversation_mgr.get_conversation_history(
@@ -678,7 +680,7 @@ class QAEngineV3:
             channel_name = metadata.get("channel_name") or summary.get("channel_name", "未知频道")
             created_at = metadata.get("created_at") or summary.get("created_at", "")
             summary_text = summary.get("summary_text", "")
-            post_links = summary.get("post_links") or metadata.get("post_links") or []
+            post_links = self._extract_post_links(summary)
 
             # 来源标签（总结 or 原始消息）
             source_tag = ""
@@ -718,7 +720,7 @@ class QAEngineV3:
             metadata = s.get("metadata", {})
             channel_id = metadata.get("channel_id") or s.get("channel_id", "")
             channel_name = metadata.get("channel_name") or s.get("channel_name", "未知频道")
-            for link in s.get("post_links") or metadata.get("post_links") or []:
+            for link in self._extract_post_links(s):
                 if link not in post_links:
                     post_links.append(link)
 
@@ -732,6 +734,15 @@ class QAEngineV3:
         if post_links:
             source_text += "\n🔗 相关帖子: " + " ".join(post_links[:5])
         return source_text
+
+    @staticmethod
+    def _extract_post_links(summary: dict[str, Any]) -> list[str]:
+        """从结果中提取帖子链接，保证 RAG 上下文和来源信息使用同一逻辑。"""
+        metadata = summary.get("metadata", {})
+        links = summary.get("post_links") or metadata.get("post_links") or []
+        if isinstance(links, str):
+            return [links]
+        return list(links)
 
     async def _resolve_channel_from_parsed(self, parsed: dict[str, Any]) -> str | None:
         """根据解析结果获取标准频道 ID。"""

--- a/core/ai/qa_engine_v3.py
+++ b/core/ai/qa_engine_v3.py
@@ -45,7 +45,8 @@ BASE_SYSTEM_TEMPLATE = """{persona_description}
 2. **上下文理解**：如果有对话历史，优先利用上下文理解代词指代（如"它"、"那个"、"这个"等）
 3. **明确回答**：总结中没有相关信息时，明确说明
 4. **结构清晰**：使用清晰的结构和要点，语言简洁专业
-5. **Markdown规范**：
+5. **引用来源**：如果上下文或工具结果中提供了 post_links，请在相关要点后引用帖子链接
+6. **Markdown规范**：
    - 粗体：使用 **文本** （两边各两个星号）
    - 斜体：使用 *文本* （两边各一个星号）
    - 代码：使用 `代码` （反引号）
@@ -83,7 +84,8 @@ AGENT_TOOL_INSTRUCTIONS = """
 3. 如果用户指定频道名、@username 或频道链接，先调用 resolve_channel，再把 channel_id 传给搜索工具
 4. 可以同时调用多个搜索工具（如语义+关键词并行检索）
 5. 评估搜索结果：结果充足则回答，不足则调整参数再次搜索
-6. 最多进行{max_iterations}轮工具调用
+6. 如果工具结果包含 post_links，最终回答必须尽量保留相关帖子链接作为证据来源
+7. 最多进行{max_iterations}轮工具调用
 """
 
 
@@ -676,6 +678,7 @@ class QAEngineV3:
             channel_name = metadata.get("channel_name") or summary.get("channel_name", "未知频道")
             created_at = metadata.get("created_at") or summary.get("created_at", "")
             summary_text = summary.get("summary_text", "")
+            post_links = summary.get("post_links") or metadata.get("post_links") or []
 
             # 来源标签（总结 or 原始消息）
             source_tag = ""
@@ -696,8 +699,13 @@ class QAEngineV3:
             if "rerank_score" in summary:
                 score_info += f" [重排分: {summary['rerank_score']:.2f}]"
 
+            links_text = ""
+            if post_links:
+                links_text = "\n相关帖子链接: " + " ".join(post_links[:5])
+
             context_parts.append(
-                f"[{i}] {channel_name} ({created_at}){source_tag}{score_info}\n{text_preview}"
+                f"[{i}] {channel_name} ({created_at}){source_tag}{score_info}\n"
+                f"{text_preview}{links_text}"
             )
 
         return "\n\n".join(context_parts)
@@ -705,10 +713,14 @@ class QAEngineV3:
     def _format_source_info_v3(self, summaries: list[dict[str, Any]]) -> str:
         """格式化来源信息（v3版本）"""
         channels = {}
+        post_links = []
         for s in summaries:
             metadata = s.get("metadata", {})
             channel_id = metadata.get("channel_id") or s.get("channel_id", "")
             channel_name = metadata.get("channel_name") or s.get("channel_name", "未知频道")
+            for link in s.get("post_links") or metadata.get("post_links") or []:
+                if link not in post_links:
+                    post_links.append(link)
 
             if channel_id not in channels:
                 channels[channel_id] = {"name": channel_name, "count": 0}
@@ -716,7 +728,10 @@ class QAEngineV3:
 
         sources = [f"• {info['name']}: {info['count']}条" for info in channels.values()]
 
-        return f"📚 数据来源: {len(sources)}个频道\n" + "\n".join(sources)
+        source_text = f"📚 数据来源: {len(sources)}个频道\n" + "\n".join(sources)
+        if post_links:
+            source_text += "\n🔗 相关帖子: " + " ".join(post_links[:5])
+        return source_text
 
     async def _resolve_channel_from_parsed(self, parsed: dict[str, Any]) -> str | None:
         """根据解析结果获取标准频道 ID。"""

--- a/core/commands/summary_commands.py
+++ b/core/commands/summary_commands.py
@@ -190,6 +190,7 @@ async def generate_channel_summary(
                             "created_at": datetime.now(UTC).isoformat(),
                             "summary_type": "manual",
                             "message_count": len(messages),
+                            "summary_message_ids": json.dumps([], ensure_ascii=False),
                         },
                     )
 
@@ -458,6 +459,7 @@ async def handle_manual_summary(event):
                                     "created_at": datetime.now(UTC).isoformat(),
                                     "summary_type": "manual",
                                     "message_count": len(messages),
+                                    "summary_message_ids": json.dumps([], ensure_ascii=False),
                                 },
                             )
 

--- a/core/handlers/realtime_rag_handler.py
+++ b/core/handlers/realtime_rag_handler.py
@@ -317,6 +317,7 @@ class RealtimeRAGHandler:
                 metadata = {
                     "channel_id": item["channel_id"],
                     "channel_name": item["channel_name"],
+                    "message_id": str(item["message_id"]),
                     "created_at": item["created_at"],
                     "sender_id": str(item["sender_id"]) if item.get("sender_id") else "",
                 }

--- a/core/infrastructure/database/base.py
+++ b/core/infrastructure/database/base.py
@@ -248,6 +248,22 @@ class DatabaseManagerBase(ABC):
         pass
 
     @abstractmethod
+    def get_channel_summary_stats(self, channel_id: str) -> dict[str, Any]:
+        """获取指定频道的总结统计"""
+        pass
+
+    @abstractmethod
+    def get_recent_summaries(
+        self,
+        channel_id: str | None = None,
+        limit: int = 5,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        """获取最近总结列表"""
+        pass
+
+    @abstractmethod
     def is_subscribed(self, user_id: int, channel_id: str, sub_type: str = "summary") -> bool:
         """检查用户是否已订阅某频道"""
         pass

--- a/core/infrastructure/database/mysql.py
+++ b/core/infrastructure/database/mysql.py
@@ -1595,23 +1595,105 @@ class MySQLManager(DatabaseManagerBase):
             return []
 
     async def get_all_channels(self) -> list[dict[str, Any]]:
-        """获取所有可用频道（从summaries表中提取）"""
+        """获取所有可用频道（从 summaries 表中提取并合并配置频道）"""
         try:
             async with self.pool.acquire() as conn:
                 async with conn.cursor(aiomysql.DictCursor) as cursor:
                     await cursor.execute("""
-                        SELECT DISTINCT channel_id, channel_name,
-                               MAX(created_at) as last_summary_time
+                        SELECT
+                            channel_id,
+                            COALESCE(MAX(NULLIF(channel_name, '')), channel_id) AS channel_name,
+                            MAX(created_at) AS last_summary_time,
+                            COUNT(*) AS summary_count,
+                            COALESCE(SUM(message_count), 0) AS message_count
                         FROM summaries
-                        GROUP BY channel_id, channel_name
+                        GROUP BY channel_id
                         ORDER BY last_summary_time DESC
                     """)
 
-                    return await cursor.fetchall()
+                    rows = await cursor.fetchall()
+
+            channels = {row["channel_id"]: row for row in rows if row.get("channel_id")}
+
+            try:
+                from core.config import CHANNELS, normalize_channel_id
+
+                for configured_channel in CHANNELS:
+                    normalized = normalize_channel_id(configured_channel)
+                    if normalized in channels:
+                        continue
+                    channels[normalized] = {
+                        "channel_id": normalized,
+                        "channel_name": normalized.split("/")[-1],
+                        "last_summary_time": None,
+                        "summary_count": 0,
+                        "message_count": 0,
+                    }
+            except Exception as e:
+                logger.warning(f"合并配置频道失败: {type(e).__name__}: {e}")
+
+            return sorted(
+                channels.values(),
+                key=lambda item: item.get("last_summary_time") or datetime.min,
+                reverse=True,
+            )
 
         except Exception as e:
             logger.error(f"获取频道列表失败: {type(e).__name__}: {e}", exc_info=True)
             return []
+
+    async def get_channel_summary_stats(self, channel_id: str) -> dict[str, Any]:
+        """获取指定频道的总结统计"""
+        try:
+            async with self.pool.acquire() as conn:
+                async with conn.cursor(aiomysql.DictCursor) as cursor:
+                    await cursor.execute(
+                        """
+                        SELECT
+                            channel_id,
+                            COALESCE(MAX(NULLIF(channel_name, '')), channel_id) AS channel_name,
+                            COUNT(*) AS summary_count,
+                            COALESCE(SUM(message_count), 0) AS message_count,
+                            MAX(created_at) AS last_summary_time,
+                            MIN(created_at) AS first_summary_time
+                        FROM summaries
+                        WHERE channel_id = %s
+                        GROUP BY channel_id
+                    """,
+                        (channel_id,),
+                    )
+                    row = await cursor.fetchone()
+
+                    if row:
+                        return row
+
+                    return {
+                        "channel_id": channel_id,
+                        "channel_name": channel_id.split("/")[-1],
+                        "summary_count": 0,
+                        "message_count": 0,
+                        "last_summary_time": None,
+                        "first_summary_time": None,
+                    }
+
+        except Exception as e:
+            logger.error(f"获取频道统计失败: {type(e).__name__}: {e}", exc_info=True)
+            return {}
+
+    async def get_recent_summaries(
+        self,
+        channel_id: str | None = None,
+        limit: int = 5,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        """获取最近总结列表"""
+        return await self.get_summaries(
+            channel_id=channel_id,
+            limit=limit,
+            start_date=start_date,
+            end_date=end_date,
+        )
 
     async def is_subscribed(self, user_id: int, channel_id: str, sub_type: str = "summary") -> bool:
         """检查用户是否已订阅某频道"""

--- a/core/qa_user_system.py
+++ b/core/qa_user_system.py
@@ -263,9 +263,12 @@ class QAUserSystem:
             channel_name = channel.get("channel_name", "未知频道")
             channel_id = channel.get("channel_id", "")
             last_time = self._format_date_field(channel.get("last_summary_time"))
+            summary_count = channel.get("summary_count", 0)
+            message_count = channel.get("message_count", 0)
             lines.append(f"{i}. **{channel_name}**")
             lines.append(f"   链接: `{channel_id}`")
-            lines.append(f"   最后更新: {last_time}")
+            lines.append(f"   总结数: {summary_count}，消息数: {message_count}")
+            lines.append(f"   最后更新: {last_time or '暂无总结'}")
             lines.append("")
 
         lines.append("💡 使用方法:")

--- a/core/system/scheduler.py
+++ b/core/system/scheduler.py
@@ -8,6 +8,7 @@
 # 本项目源代码：https://github.com/Sakura520222/Sakura-Bot
 # 许可证全文：参见 LICENSE 文件
 
+import json
 from datetime import UTC, datetime, timedelta
 
 import core.config as config_module
@@ -244,6 +245,9 @@ async def main_job(channel=None):
                                         "created_at": datetime.now(UTC).isoformat(),
                                         "summary_type": frequency,  # 'daily' 或 'weekly'
                                         "message_count": len(messages),
+                                        "summary_message_ids": json.dumps(
+                                            summary_ids, ensure_ascii=False
+                                        ),
                                     },
                                 )
 

--- a/core/telegram/messaging.py
+++ b/core/telegram/messaging.py
@@ -3,6 +3,7 @@ Telegram消息发送模块
 包含消息抓取、长消息发送和报告发送功能
 """
 
+import json
 import logging
 from datetime import UTC, datetime, timedelta
 
@@ -861,6 +862,9 @@ async def send_report(
                                     "created_at": datetime.now(UTC).isoformat(),
                                     "summary_type": "manual",
                                     "message_count": message_count,
+                                    "summary_message_ids": json.dumps(
+                                        report_message_ids, ensure_ascii=False
+                                    ),
                                 },
                             )
 

--- a/qa_bot.py
+++ b/qa_bot.py
@@ -444,17 +444,17 @@ class QABot:
         )
 
         if not context.args or len(context.args) < 2:
-            message = """🔎 **指定频道查询**
+            message = """🔎 <b>指定频道查询</b>
 
 使用方法:
-`/ask <频道链接或@用户名> <问题>`
+<code>/ask &lt;频道链接或@用户名&gt; &lt;问题&gt;</code>
 
 示例:
-`/ask @channel_name 最近有什么更新？`
-`/ask https://t.me/channel_name 分析一下 AI 讨论`
+<code>/ask @channel_name 最近有什么更新？</code>
+<code>/ask https://t.me/channel_name 分析一下 AI 讨论</code>
 
-💡 使用 `/listchannels` 查看可查询频道。"""
-            await update.message.reply_text(message, parse_mode="Markdown")
+💡 使用 <code>/listchannels</code> 查看可查询频道。"""
+            await update.message.reply_text(message, parse_mode="HTML")
             return
 
         channel_hint = context.args[0]

--- a/qa_bot.py
+++ b/qa_bot.py
@@ -165,6 +165,7 @@ class QABot:
 • `/status` - 查看使用配额和会话状态
 • `/clear` - 清除对话记忆，重新开始
 • `/view_persona` - 查看当前助手人格设定
+• `/ask <频道> <问题>` - 限定指定频道查询
 
 *订阅管理*
 • `/listchannels` - 列出可订阅的频道
@@ -179,6 +180,11 @@ class QABot:
 • "最近有什么技术讨论？"
 • "今天有什么更新？"
 • "关于特定关键词的内容"
+
+*指定频道查询*
+• `/ask @channel_name 最近有什么更新？`
+• `/ask https://t.me/channel_name 分析一下 AI 讨论`
+• 也可以直接说："在 channel_name 频道里查 AI"
 
 *多轮对话*
 • 我会记住我们的对话上下文（30分钟内）
@@ -429,6 +435,52 @@ class QABot:
         result = await self.user_system.create_summary_request(user_id, channel_url, channel_name)
         await update.message.reply_text(result["message"], parse_mode="HTML")
 
+    async def ask_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """处理/ask命令 - 限定指定频道查询"""
+        user_id = update.effective_user.id
+
+        await self.user_system.register_user(
+            user_id, update.effective_user.username, update.effective_user.first_name
+        )
+
+        if not context.args or len(context.args) < 2:
+            message = """🔎 **指定频道查询**
+
+使用方法:
+`/ask <频道链接或@用户名> <问题>`
+
+示例:
+`/ask @channel_name 最近有什么更新？`
+`/ask https://t.me/channel_name 分析一下 AI 讨论`
+
+💡 使用 `/listchannels` 查看可查询频道。"""
+            await update.message.reply_text(message, parse_mode="Markdown")
+            return
+
+        channel_hint = context.args[0]
+        query = " ".join(context.args[1:]).strip()
+        if not query:
+            await update.message.reply_text("请提供要查询的问题。")
+            return
+
+        try:
+            quota_check = await self.quota_manager.check_quota(user_id)
+            if not quota_check.get("allowed", False):
+                await update.message.reply_text(quota_check.get("message", "配额不足"))
+                return
+
+            placeholder = await update.message.reply_text("🔍 正在限定频道检索相关记录...")
+            await self._stream_and_edit(
+                placeholder=placeholder,
+                query=query,
+                user_id=user_id,
+                quota_check=quota_check,
+                channel_hint=channel_hint,
+            )
+        except Exception as e:
+            logger.error(f"处理指定频道查询失败: {type(e).__name__}: {e}", exc_info=True)
+            await update.message.reply_text("❌ 抱歉，处理查询时出错。请稍后再试。")
+
     async def handle_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """处理用户消息（流式输出 - 单条消息动态编辑）"""
         # 防御性检查：忽略非用户消息（如频道事件、系统消息）
@@ -471,7 +523,12 @@ class QABot:
                 pass
 
     async def _stream_and_edit(
-        self, placeholder, query: str, user_id: int, quota_check: dict
+        self,
+        placeholder,
+        query: str,
+        user_id: int,
+        quota_check: dict,
+        channel_hint: str | None = None,
     ) -> None:
         """
         流式接收 QA 引擎输出，并实时编辑 Telegram 消息。
@@ -567,7 +624,7 @@ class QABot:
             last_edit_time = time.monotonic()
 
         try:
-            async for chunk in self.qa_engine.process_query_stream(query, user_id):
+            async for chunk in self.qa_engine.process_query_stream(query, user_id, channel_hint):
                 # ── 处理特殊控制标记 ─────────────────────────────────────────
                 if chunk == "__DONE__":
                     break
@@ -727,6 +784,7 @@ class QABot:
                 BotCommand("status", "查看使用配额和会话状态"),
                 BotCommand("clear", "清除对话记忆"),
                 BotCommand("view_persona", "查看当前助手人格设定"),
+                BotCommand("ask", "限定指定频道查询"),
                 BotCommand("listchannels", "列出可订阅的频道"),
                 BotCommand("subscribe", "订阅频道总结推送"),
                 BotCommand("unsubscribe", "取消频道订阅"),
@@ -762,6 +820,7 @@ class QABot:
         self.application.add_handler(CommandHandler("status", self.status_command))
         self.application.add_handler(CommandHandler("clear", self.clear_command))
         self.application.add_handler(CommandHandler("view_persona", self.view_persona_command))
+        self.application.add_handler(CommandHandler("ask", self.ask_command))
 
         # 订阅管理命令
         self.application.add_handler(CommandHandler("listchannels", self.list_channels_command))

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -110,6 +110,7 @@ def test_get_all_results_includes_doc_results_without_duplicates(executor):
     executor._store_result(summary_result)
     executor._store_result(message_result)
     executor._store_result(duplicated_result)
+    executor._doc_result_store[duplicated_result["doc_id"]] = dict(duplicated_result)
 
     results = executor.get_all_results()
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Sakura-Bot
+#
+# 本项目采用 GNU Affero General Public License Version 3.0 (AGPL-3.0) 许可
+#
+# - 署名：必须提供本项目的原始来源链接
+# - 相同方式共享：衍生作品必须采用相同的许可证
+#
+# 本项目源代码：https://github.com/Sakura520222/Sakura-Bot
+# 许可证全文：参见 LICENSE 文件
+
+"""测试 Agentic RAG 工具执行器"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.ai.agent_tools import TOOL_SCHEMAS, ToolExecutor
+
+
+@pytest.fixture
+def executor():
+    """创建工具执行器"""
+    vector_store = MagicMock()
+    vector_store.is_available.return_value = True
+    vector_store.is_messages_available.return_value = True
+    memory_manager = MagicMock()
+    reranker = MagicMock()
+    reranker.is_available.return_value = False
+    return ToolExecutor(vector_store, memory_manager, reranker)
+
+
+def test_tool_schemas_include_channel_tools():
+    """测试工具定义包含频道相关工具"""
+    names = {tool["function"]["name"] for tool in TOOL_SCHEMAS}
+
+    assert "list_channels" in names
+    assert "resolve_channel" in names
+    assert "get_recent_summaries" in names
+    assert "get_channel_stats" in names
+    assert "get_source_detail" in names
+
+
+@pytest.mark.asyncio
+async def test_execute_list_channels_returns_channels(executor):
+    """测试列出频道工具"""
+    executor.memory_manager.list_channels = AsyncMock(
+        return_value=[
+            {"channel_id": "https://t.me/test", "channel_name": "Test", "summary_count": 1}
+        ]
+    )
+
+    result = json.loads(await executor.execute("list_channels", {"limit": 10}))
+
+    assert result["count"] == 1
+    assert result["channels"][0]["channel_id"] == "https://t.me/test"
+
+
+@pytest.mark.asyncio
+async def test_execute_resolve_channel_returns_match(executor):
+    """测试解析频道工具"""
+    executor.memory_manager.resolve_channel = AsyncMock(
+        return_value={"success": True, "channel_id": "https://t.me/test"}
+    )
+
+    result = json.loads(await executor.execute("resolve_channel", {"channel_hint": "@test"}))
+
+    assert result["success"] is True
+    assert result["channel_id"] == "https://t.me/test"
+
+
+@pytest.mark.asyncio
+async def test_execute_semantic_search_uses_channel_filter(executor):
+    """测试语义检索传递频道过滤"""
+    executor.vector_store.search_all.return_value = [
+        {
+            "summary_id": 1,
+            "summary_text": "完整内容",
+            "metadata": {"channel_id": "https://t.me/test", "channel_name": "Test"},
+            "doc_id": "https://t.me/test:1",
+            "source": "message",
+        }
+    ]
+
+    result = json.loads(
+        await executor.execute(
+            "semantic_search",
+            {"query": "AI", "channel_id": "https://t.me/test", "collection": "all"},
+        )
+    )
+
+    assert result["count"] == 1
+    executor.vector_store.search_all.assert_called_once()
+    call_kwargs = executor.vector_store.search_all.call_args.kwargs
+    assert call_kwargs["filter_metadata"] == {"channel_id": "https://t.me/test"}
+
+
+@pytest.mark.asyncio
+async def test_execute_source_detail_returns_full_text(executor):
+    """测试来源详情返回完整文本"""
+    executor.vector_store.search_all.return_value = [
+        {
+            "summary_id": 1,
+            "summary_text": "很长的完整内容" * 100,
+            "metadata": {"channel_id": "https://t.me/test", "channel_name": "Test"},
+            "doc_id": "https://t.me/test:1",
+        }
+    ]
+    await executor.execute("semantic_search", {"query": "AI"})
+
+    result = json.loads(await executor.execute("get_source_detail", {"summary_id": 1}))
+
+    assert "detail" in result
+    assert len(result["detail"]["summary_text"]) > 500

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -41,6 +41,54 @@ def test_tool_schemas_include_channel_tools():
     assert "get_source_detail" in names
 
 
+def test_serialize_result_builds_message_post_link():
+    """测试消息向量结果会生成帖子链接"""
+    result = {
+        "summary_id": 1,
+        "summary_text": "消息内容",
+        "doc_id": "https://t.me/test:123",
+        "metadata": {"channel_id": "https://t.me/test", "channel_name": "Test"},
+    }
+
+    serialized = ToolExecutor._serialize_result(result)
+
+    assert serialized["post_links"] == ["https://t.me/test/123"]
+
+
+def test_build_summary_post_links_uses_summary_message_ids():
+    """测试总结结果会根据 summary_message_ids 生成帖子链接"""
+    summary = {
+        "channel_id": "https://t.me/test",
+        "summary_message_ids": [10, 11, 12],
+    }
+
+    links = ToolExecutor._build_summary_post_links(summary)
+
+    assert links == [
+        "https://t.me/test/10",
+        "https://t.me/test/11",
+        "https://t.me/test/12",
+    ]
+
+
+def test_serialize_result_builds_summary_post_links_from_metadata_json():
+    """测试总结向量元数据中的消息 ID 会生成帖子链接"""
+    result = {
+        "summary_id": 1,
+        "summary_text": "总结内容",
+        "metadata": {
+            "channel_id": "https://t.me/test",
+            "channel_name": "Test",
+            "summary_message_ids": "[10, 11]",
+        },
+        "source": "summary",
+    }
+
+    serialized = ToolExecutor._serialize_result(result)
+
+    assert serialized["post_links"] == ["https://t.me/test/10", "https://t.me/test/11"]
+
+
 @pytest.mark.asyncio
 async def test_execute_list_channels_returns_channels(executor):
     """测试列出频道工具"""
@@ -90,6 +138,7 @@ async def test_execute_semantic_search_uses_channel_filter(executor):
     )
 
     assert result["count"] == 1
+    assert result["results"][0]["post_links"] == ["https://t.me/test/1"]
     executor.vector_store.search_all.assert_called_once()
     call_kwargs = executor.vector_store.search_all.call_args.kwargs
     assert call_kwargs["filter_metadata"] == {"channel_id": "https://t.me/test"}

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -89,6 +89,35 @@ def test_serialize_result_builds_summary_post_links_from_metadata_json():
     assert serialized["post_links"] == ["https://t.me/test/10", "https://t.me/test/11"]
 
 
+def test_build_post_link_rejects_invalid_sources():
+    """测试帖子链接构造会拒绝无效或私有来源"""
+    assert ToolExecutor._build_post_link(None, 1) is None
+    assert ToolExecutor._build_post_link("https://t.me/+private", 1) is None
+    assert ToolExecutor._build_post_link("https://t.me/test", "abc") is None
+    assert ToolExecutor._build_post_link("@test_channel", 123) == "https://t.me/test_channel/123"
+
+
+def test_get_all_results_includes_doc_results_without_duplicates(executor):
+    """测试获取全部结果时包含仅 doc_id 索引的消息结果并去重"""
+    summary_result = {"summary_id": 1, "summary_text": "总结"}
+    message_result = {"summary_text": "消息", "doc_id": "https://t.me/test:2"}
+    duplicated_result = {
+        "summary_id": 3,
+        "summary_text": "同时有两个索引",
+        "doc_id": "https://t.me/test:3",
+    }
+
+    executor._store_result(summary_result)
+    executor._store_result(message_result)
+    executor._store_result(duplicated_result)
+
+    results = executor.get_all_results()
+
+    assert summary_result in results
+    assert message_result in results
+    assert results.count(duplicated_result) == 1
+
+
 @pytest.mark.asyncio
 async def test_execute_list_channels_returns_channels(executor):
     """测试列出频道工具"""

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -15,7 +15,7 @@ from core.ai.memory_manager import MemoryManager, get_memory_manager
 class TestMemoryManagerInit:
     """初始化测试"""
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     def test_init(self, mock_get_db):
         """测试初始化"""
         mock_db = MagicMock()
@@ -30,9 +30,9 @@ class TestMemoryManagerInit:
 class TestExtractMetadata:
     """提取元数据测试"""
 
-    @patch("core.memory_manager.client_llm")
-    @patch("core.memory_manager.get_llm_model")
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.client_llm")
+    @patch("core.ai.memory_manager.get_llm_model")
+    @patch("core.ai.memory_manager.get_db_manager")
     def test_extract_metadata_success(self, mock_get_db, mock_model, mock_client):
         """测试成功提取元数据"""
         mock_db = MagicMock()
@@ -56,7 +56,7 @@ class TestExtractMetadata:
         assert "keywords" in metadata
         assert "topics" in metadata
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     def test_extract_metadata_default(self, mock_get_db):
         """测试提取元数据失败时返回默认值"""
         mock_db = MagicMock()
@@ -74,7 +74,7 @@ class TestExtractMetadata:
 class TestUpdateChannelProfile:
     """更新频道画像测试"""
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     @pytest.mark.asyncio
     async def test_update_channel_profile(self, mock_get_db):
         """测试更新频道画像"""
@@ -98,7 +98,7 @@ class TestUpdateChannelProfile:
 class TestGetChannelContext:
     """获取频道上下文测试"""
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     @pytest.mark.asyncio
     async def test_get_channel_context_with_profile(self, mock_get_db):
         """测试获取有画像的频道上下文"""
@@ -118,7 +118,7 @@ class TestGetChannelContext:
 
         assert "技术专业" in context or "特点" in context
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     @pytest.mark.asyncio
     async def test_get_channel_context_no_profile(self, mock_get_db):
         """测试获取无画像的频道上下文"""
@@ -131,7 +131,7 @@ class TestGetChannelContext:
 
         assert "test" in context.lower()
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     @pytest.mark.asyncio
     async def test_get_channel_context_no_channel(self, mock_get_db):
         """测试获取无频道ID的上下文"""
@@ -145,10 +145,68 @@ class TestGetChannelContext:
 
 
 @pytest.mark.unit
+class TestChannelDirectory:
+    """频道目录测试"""
+
+    @patch("core.ai.memory_manager.get_db_manager")
+    @pytest.mark.asyncio
+    async def test_list_channels_returns_normalized_rows(self, mock_get_db):
+        """测试获取标准化频道列表"""
+        mock_db = MagicMock()
+        mock_db.get_all_channels = AsyncMock(
+            return_value=[
+                {
+                    "channel_id": "https://t.me/test",
+                    "channel_name": "Test",
+                    "summary_count": "2",
+                    "message_count": None,
+                }
+            ]
+        )
+        mock_get_db.return_value = mock_db
+
+        manager = MemoryManager()
+        channels = await manager.list_channels()
+
+        assert channels[0]["summary_count"] == 2
+        assert channels[0]["message_count"] == 0
+
+    @patch("core.ai.memory_manager.get_db_manager")
+    @pytest.mark.asyncio
+    async def test_resolve_channel_exact_match(self, mock_get_db):
+        """测试精确解析频道"""
+        mock_db = MagicMock()
+        mock_db.get_all_channels = AsyncMock(
+            return_value=[{"channel_id": "https://t.me/test", "channel_name": "Test Channel"}]
+        )
+        mock_get_db.return_value = mock_db
+
+        manager = MemoryManager()
+        result = await manager.resolve_channel("@test")
+
+        assert result["success"] is True
+        assert result["channel_id"] == "https://t.me/test"
+
+    @patch("core.ai.memory_manager.get_db_manager")
+    @pytest.mark.asyncio
+    async def test_get_recent_summaries_delegates_to_db(self, mock_get_db):
+        """测试最近总结调用数据库接口"""
+        mock_db = MagicMock()
+        mock_db.get_recent_summaries = AsyncMock(return_value=[{"id": 1}])
+        mock_get_db.return_value = mock_db
+
+        manager = MemoryManager()
+        results = await manager.get_recent_summaries("https://t.me/test", limit=3)
+
+        assert results == [{"id": 1}]
+        mock_db.get_recent_summaries.assert_awaited_once()
+
+
+@pytest.mark.unit
 class TestSearchSummaries:
     """搜索总结测试"""
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     @pytest.mark.asyncio
     async def test_search_summaries_no_filters(self, mock_get_db):
         """测试无过滤条件的搜索"""
@@ -161,7 +219,7 @@ class TestSearchSummaries:
 
         assert len(results) == 1
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     @pytest.mark.asyncio
     async def test_search_summaries_with_keywords(self, mock_get_db):
         """测试带关键词的搜索"""
@@ -176,7 +234,7 @@ class TestSearchSummaries:
 
         assert len(results) == 1
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     @pytest.mark.asyncio
     async def test_search_summaries_empty_result(self, mock_get_db):
         """测试搜索无结果"""
@@ -194,24 +252,24 @@ class TestSearchSummaries:
 class TestGetMemoryManager:
     """获取全局实例测试"""
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     def test_singleton(self, mock_get_db):
         """测试单例模式"""
-        import core.memory_manager
+        import core.ai.memory_manager
 
-        core.memory_manager.memory_manager = None
+        core.ai.memory_manager.memory_manager = None
 
         manager1 = get_memory_manager()
         manager2 = get_memory_manager()
 
         assert manager1 is manager2
 
-    @patch("core.memory_manager.get_db_manager")
+    @patch("core.ai.memory_manager.get_db_manager")
     def test_returns_memory_manager_instance(self, mock_get_db):
         """测试返回MemoryManager实例"""
-        import core.memory_manager
+        import core.ai.memory_manager
 
-        core.memory_manager.memory_manager = None
+        core.ai.memory_manager.memory_manager = None
 
         manager = get_memory_manager()
 

--- a/tests/test_qa_user_system.py
+++ b/tests/test_qa_user_system.py
@@ -277,6 +277,8 @@ def test_format_channels_list(qa_user_system):
             "channel_id": "https://t.me/test_channel",
             "channel_name": "Test Channel",
             "last_summary_time": "2026-02-24",
+            "summary_count": 3,
+            "message_count": 42,
         }
     ]
 
@@ -286,6 +288,7 @@ def test_format_channels_list(qa_user_system):
     assert "Test Channel" in result
     assert "https://t.me/test_channel" in result
     assert "2026-02-24" in result
+    assert "总结数: 3" in result
 
 
 def test_format_channels_list_empty(qa_user_system):

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -15,8 +15,8 @@ from core.ai.vector_store import VectorStore, get_vector_store
 class TestVectorStoreInit:
     """初始化测试"""
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", True)
-    @patch("core.vector_store.chromadb.PersistentClient")
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", True)
+    @patch("core.ai.vector_store.chromadb.PersistentClient")
     def test_init_success(self, mock_client):
         """测试成功初始化"""
         mock_collection = MagicMock()
@@ -27,7 +27,7 @@ class TestVectorStoreInit:
 
         assert store.client is not None
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", False)
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", False)
     def test_init_chromadb_not_available(self):
         """测试ChromaDB不可用"""
         store = VectorStore()
@@ -40,15 +40,15 @@ class TestVectorStoreInit:
 class TestIsAvailable:
     """可用性测试"""
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", False)
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", False)
     def test_is_available_when_unavailable(self):
         """测试不可用时返回False"""
         store = VectorStore()
 
         assert store.is_available() is False
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", True)
-    @patch("core.vector_store.chromadb.PersistentClient")
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", True)
+    @patch("core.ai.vector_store.chromadb.PersistentClient")
     def test_is_available_when_available(self, mock_client):
         """测试可用时返回True"""
         mock_collection = MagicMock()
@@ -63,7 +63,7 @@ class TestIsAvailable:
 class TestAddSummary:
     """添加总结测试"""
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", False)
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", False)
     def test_add_summary_unavailable(self):
         """测试不可用时添加失败"""
         store = VectorStore()
@@ -72,9 +72,9 @@ class TestAddSummary:
 
         assert result is False
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", True)
-    @patch("core.vector_store.chromadb.PersistentClient")
-    @patch("core.embedding_generator.get_embedding_generator")
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", True)
+    @patch("core.ai.vector_store.chromadb.PersistentClient")
+    @patch("core.ai.embedding_generator.get_embedding_generator")
     def test_add_summary_success(self, mock_get_emb, mock_client):
         """测试成功添加"""
         mock_collection = MagicMock()
@@ -90,9 +90,9 @@ class TestAddSummary:
 
         assert result is True
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", True)
-    @patch("core.vector_store.chromadb.PersistentClient")
-    @patch("core.embedding_generator.get_embedding_generator")
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", True)
+    @patch("core.ai.vector_store.chromadb.PersistentClient")
+    @patch("core.ai.embedding_generator.get_embedding_generator")
     def test_add_summary_embedding_failed(self, mock_get_emb, mock_client):
         """测试embedding生成失败"""
         mock_collection = MagicMock()
@@ -113,7 +113,7 @@ class TestAddSummary:
 class TestSearchSimilar:
     """搜索相似总结测试"""
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", False)
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", False)
     def test_search_similar_unavailable(self):
         """测试不可用时搜索失败"""
         store = VectorStore()
@@ -122,9 +122,9 @@ class TestSearchSimilar:
 
         assert results == []
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", True)
-    @patch("core.vector_store.chromadb.PersistentClient")
-    @patch("core.embedding_generator.get_embedding_generator")
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", True)
+    @patch("core.ai.vector_store.chromadb.PersistentClient")
+    @patch("core.ai.embedding_generator.get_embedding_generator")
     def test_search_similar_success(self, mock_get_emb, mock_client):
         """测试成功搜索"""
         mock_collection = MagicMock()
@@ -148,9 +148,9 @@ class TestSearchSimilar:
         assert len(results) == 2
         assert results[0]["summary_id"] == 1
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", True)
-    @patch("core.vector_store.chromadb.PersistentClient")
-    @patch("core.embedding_generator.get_embedding_generator")
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", True)
+    @patch("core.ai.vector_store.chromadb.PersistentClient")
+    @patch("core.ai.embedding_generator.get_embedding_generator")
     def test_search_similar_empty_results(self, mock_get_emb, mock_client):
         """测试搜索无结果"""
         mock_collection = MagicMock()
@@ -172,7 +172,7 @@ class TestSearchSimilar:
 class TestDeleteSummary:
     """删除总结测试"""
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", False)
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", False)
     def test_delete_summary_unavailable(self):
         """测试不可用时删除失败"""
         store = VectorStore()
@@ -181,8 +181,8 @@ class TestDeleteSummary:
 
         assert result is False
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", True)
-    @patch("core.vector_store.chromadb.PersistentClient")
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", True)
+    @patch("core.ai.vector_store.chromadb.PersistentClient")
     def test_delete_summary_success(self, mock_client):
         """测试成功删除"""
         mock_collection = MagicMock()
@@ -198,7 +198,7 @@ class TestDeleteSummary:
 class TestGetStats:
     """获取统计信息测试"""
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", False)
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", False)
     def test_get_stats_unavailable(self):
         """测试不可用时获取统计"""
         store = VectorStore()
@@ -206,8 +206,8 @@ class TestGetStats:
 
         assert stats["available"] is False
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", True)
-    @patch("core.vector_store.chromadb.PersistentClient")
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", True)
+    @patch("core.ai.vector_store.chromadb.PersistentClient")
     def test_get_stats_success(self, mock_client):
         """测试成功获取统计"""
         mock_collection = MagicMock()
@@ -225,24 +225,24 @@ class TestGetStats:
 class TestGetVectorStore:
     """获取全局实例测试"""
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", False)
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", False)
     def test_singleton(self):
         """测试单例模式"""
-        import core.vector_store
+        import core.ai.vector_store
 
-        core.vector_store.vector_store = None
+        core.ai.vector_store.vector_store = None
 
         store1 = get_vector_store()
         store2 = get_vector_store()
 
         assert store1 is store2
 
-    @patch("core.vector_store.CHROMADB_AVAILABLE", False)
+    @patch("core.ai.vector_store.CHROMADB_AVAILABLE", False)
     def test_returns_vector_store_instance(self):
         """测试返回VectorStore实例"""
-        import core.vector_store
+        import core.ai.vector_store
 
-        core.vector_store.vector_store = None
+        core.ai.vector_store.vector_store = None
 
         store = get_vector_store()
 


### PR DESCRIPTION
实现了从总结或结果中构造 Telegram 帖子链接的功能，并新增了多个工具函数以优化频道信息的获取和处理。更新了相关的系统提示和用户查询命令，以支持指定频道的查询。

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 为核心工具和问答引擎增加了**帖子链接支持**，并进行了重要的代码重构与优化，显著增强了系统引用外部帖子的能力与检索效率。共涉及 16 个文件，新增 1056 行，删除 82 行，净增 974 行。

### 主要改动
- **新增功能**：`agent_tools.py` 和 `qa_engine_v3.py` 增加帖子链接的处理与返回逻辑，使 AI 能在回答中直接引用具体帖子；`mysql.py` 新增帖子链接的存储与查询方法。
- **意图与记忆增强**：`intent_parser.py` 新增解析帖子链接的意图；`memory_manager.py` 强化记忆关联帖子的能力。
- **重构与优化**（87f4e22）：优化 `agent_tools.py` 中的结果去重逻辑（避免依赖对象 id），并修正了 QA 引擎的静态方法调用。
- **频道搜索优化**（564e231）：优化频道搜索与结果处理逻辑，提升相关内容检索质量。
- **测试覆盖**：更新 `test_agent_tools.py`（+1 行），新增 `test_agent_tools.py`（29 行），确保新功能及重构逻辑的稳定性。

### 影响范围
- **核心模块**：AI 工具链、问答引擎、记忆管理、意图解析
- **调度与消息**：`scheduler.py` 和 `messaging.py` 小幅调整以支持链接传递
- **测试**：相关测试用例更新

本次更新为非破坏性增强，提升了帖子内容的可追溯性与交互体验，并提高了代码的健壮性与可维护性。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    qa_engine_v3.py --> agent_tools.py
    test_agent_tools.py --> agent_tools.py
    qa_engine_v3.py --> memory_manager.py
    qa_engine_v3.py --> intent_parser.py
    qa_engine_v3.py --> .conversation_manager
    qa_bot.py --> qa_engine_v3.py

    qa_engine_v3.py -.-> .reranker
    qa_engine_v3.py -.-> vector_store.py
    qa_engine_v3.py -.-> database
    qa_engine_v3.py -.-> ai_client
    memory_manager.py -.-> database
    qa_bot.py -.-> qa_user_system.py
    qa_bot.py -.-> .conversation_manager

    style qa_engine_v3.py stroke:#333,stroke-width:2px
    style agent_tools.py stroke:#333,stroke-width:2px
    style memory_manager.py stroke:#333,stroke-width:2px
    style intent_parser.py stroke:#333,stroke-width:2px
    style qa_bot.py stroke:#333,stroke-width:2px
    style test_agent_tools.py stroke:#333,stroke-width:2px
```

<!-- sakura-ai-depgraph-end -->