### PR TITLE
Add fallback forwarding and explicit hot reload on config save

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -12,4 +12,4 @@
 Sakura-Bot - 核心模块
 """
 
-__version__ = "1.8.7"
+__version__ = "1.8.8"

--- a/core/bootstrap/app_bootstrap.py
+++ b/core/bootstrap/app_bootstrap.py
@@ -75,7 +75,7 @@ class AppBootstrap:
         self.startup_notifier = StartupNotifier(
             version=version, system_config_manager=self.system_config_manager
         )
-        self.web_api_initializer = WebAPIInitializer()
+        self.web_api_initializer = WebAPIInitializer(config_manager=config_manager)
 
     async def run(self) -> None:
         """运行应用引导流程

--- a/core/config/manager.py
+++ b/core/config/manager.py
@@ -179,6 +179,10 @@ class ConfigManager:
                 logger.error(f"配置验证失败: {error_event.error}")
                 return False, rollback_event.error
 
+            if config_dict == self._config_snapshot:
+                logger.debug("配置文件内容与当前快照一致，跳过重复热重载")
+                return True, ""
+
             # 4. 验证成功：原子更新配置快照
             old_config = self._config_snapshot
             async with self._write_lock:

--- a/core/forwarding/forwarding_handler.py
+++ b/core/forwarding/forwarding_handler.py
@@ -364,8 +364,8 @@ class ForwardingHandler:
                 )
             else:
                 # 使用转发模式（显示转发来源）
-                await self.sending_client.forward_messages(
-                    entity=target_channel,
+                await self._forward_messages_with_fallback(
+                    target_channel=target_channel,
                     messages=message,
                     from_peer=message.chat_id,
                 )
@@ -608,8 +608,8 @@ class ForwardingHandler:
                     )
             else:
                 # 转发模式：使用forward_messages批量转发
-                await self.sending_client.forward_messages(
-                    entity=target_channel,
+                await self._forward_messages_with_fallback(
+                    target_channel=target_channel,
                     messages=media_group_messages,
                     from_peer=message.chat_id,
                 )
@@ -642,6 +642,35 @@ class ForwardingHandler:
         except Exception as e:
             logger.error(f"转发媒体组失败: {type(e).__name__}: {e}", exc_info=True)
             return False
+
+    async def _forward_messages_with_fallback(
+        self,
+        target_channel: str,
+        messages: "Message | list[Message]",
+        from_peer: int,
+    ) -> None:
+        """转发消息，发送客户端无法解析源实体时回退到监听客户端。
+
+        Args:
+            target_channel: 目标频道
+            messages: 待转发消息或消息列表
+            from_peer: 源频道 ID
+        """
+        try:
+            await self.sending_client.forward_messages(
+                entity=target_channel,
+                messages=messages,
+                from_peer=from_peer,
+            )
+        except ValueError as e:
+            logger.warning(
+                f"发送客户端无法解析源频道实体，尝试使用监听客户端转发: {type(e).__name__}: {e}"
+            )
+            await self.monitoring_client.forward_messages(
+                entity=target_channel,
+                messages=messages,
+                from_peer=from_peer,
+            )
 
     async def _forward_media_group_with_download(
         self,
@@ -917,6 +946,12 @@ class ForwardingHandler:
             # 模式1：自定义底栏（优先级最高）
             custom_footer = rule.get("custom_footer", "").strip()
             if custom_footer:
+                assistant_bot_link = ""
+                submission_link = ""
+                if QA_BOT_USERNAME:
+                    assistant_bot_link = f"[助手BOT](https://t.me/{QA_BOT_USERNAME})"
+                    submission_link = f"[投稿](https://t.me/{QA_BOT_USERNAME}?start=submit)"
+
                 # 安全替换占位符（使用 .replace() 避免 str.format() 的大括号冲突）
                 mapping = {
                     "{source_link}": source_link,
@@ -925,6 +960,8 @@ class ForwardingHandler:
                     "{source_channel}": source_channel,
                     "{target_channel}": target_username if target_username else target_channel,
                     "{message_id}": str(message.id),
+                    "{assistant_bot}": assistant_bot_link,
+                    "{submission}": submission_link,
                 }
 
                 footer_text = custom_footer

--- a/core/forwarding/forwarding_handler.py
+++ b/core/forwarding/forwarding_handler.py
@@ -169,8 +169,7 @@ class ForwardingHandler:
             new_rules_count = len(forwarding_config.get("rules", []))
 
             # 更新配置和启用状态
-            self._config = forwarding_config
-            self._source_channel_ids = self._extract_source_channel_ids(forwarding_config)
+            self.set_config(forwarding_config)
             self._enabled = forwarding_config.get("enabled", False)
 
             # 记录状态变化
@@ -689,6 +688,8 @@ class ForwardingHandler:
                 from_peer=from_peer,
             )
         except ValueError as e:
+            # Telethon 在 forward_messages 无法解析 from_peer 实体时会抛出 ValueError，
+            # 此时改用监听客户端（通常是 UserBot）进行回退转发。
             logger.warning(
                 f"发送客户端无法解析源频道实体，尝试使用监听客户端转发: {type(e).__name__}: {e}"
             )

--- a/core/forwarding/forwarding_handler.py
+++ b/core/forwarding/forwarding_handler.py
@@ -73,6 +73,7 @@ class ForwardingHandler:
         self._event_bus = event_bus
         self._enabled = False
         self._config = {}
+        self._source_channel_ids: set[str] = set()
         # 媒体组缓存：{grouped_id: [messages]}
         # 用于收集媒体组的所有消息（Bot无法访问频道历史）
         self._media_group_cache: dict[int, list[Message]] = {}
@@ -110,6 +111,11 @@ class ForwardingHandler:
         """获取转发配置"""
         return self._config
 
+    @property
+    def source_channel_ids(self) -> set[str]:
+        """获取当前转发规则源频道ID集合"""
+        return self._source_channel_ids.copy()
+
     def set_config(self, config: dict[str, Any]):
         """
         设置转发配置
@@ -118,7 +124,25 @@ class ForwardingHandler:
             config: 配置字典
         """
         self._config = copy.deepcopy(config)
+        self._source_channel_ids = self._extract_source_channel_ids(self._config)
         logger.info(f"转发配置已更新: {len(config.get('rules', []))} 条规则")
+
+    @staticmethod
+    def _extract_source_channel_ids(config: dict[str, Any]) -> set[str]:
+        """从转发配置中提取源频道ID集合
+
+        Args:
+            config: 转发配置字典
+
+        Returns:
+            源频道ID集合
+        """
+        source_channel_ids = set()
+        for rule in config.get("rules", []):
+            source_url = rule.get("source_channel", "")
+            if source_url:
+                source_channel_ids.add(source_url.rstrip("/").split("/")[-1])
+        return source_channel_ids
 
     async def on_config_updated(self, event: ConfigChangedEvent):
         """配置更新处理
@@ -146,6 +170,7 @@ class ForwardingHandler:
 
             # 更新配置和启用状态
             self._config = forwarding_config
+            self._source_channel_ids = self._extract_source_channel_ids(forwarding_config)
             self._enabled = forwarding_config.get("enabled", False)
 
             # 记录状态变化
@@ -667,11 +692,18 @@ class ForwardingHandler:
             logger.warning(
                 f"发送客户端无法解析源频道实体，尝试使用监听客户端转发: {type(e).__name__}: {e}"
             )
-            await self.monitoring_client.forward_messages(
-                entity=target_channel,
-                messages=messages,
-                from_peer=from_peer,
-            )
+            try:
+                await self.monitoring_client.forward_messages(
+                    entity=target_channel,
+                    messages=messages,
+                    from_peer=from_peer,
+                )
+            except Exception as fallback_e:
+                logger.error(
+                    f"监听客户端回退转发也失败: {type(fallback_e).__name__}: {fallback_e}",
+                    exc_info=True,
+                )
+                raise
 
     async def _forward_media_group_with_download(
         self,
@@ -947,11 +979,7 @@ class ForwardingHandler:
             # 模式1：自定义底栏（优先级最高）
             custom_footer = rule.get("custom_footer", "").strip()
             if custom_footer:
-                assistant_bot_link = ""
-                submission_link = ""
-                if QA_BOT_USERNAME:
-                    assistant_bot_link = f"[助手BOT](https://t.me/{QA_BOT_USERNAME})"
-                    submission_link = f"[投稿](https://t.me/{QA_BOT_USERNAME}?start=submit)"
+                assistant_bot_link, submission_link = self._build_qa_bot_links()
 
                 # 安全替换占位符（使用 .replace() 避免 str.format() 的大括号冲突）
                 mapping = {
@@ -985,15 +1013,31 @@ class ForwardingHandler:
             else:
                 footer_parts.append(target_channel)
 
-            if QA_BOT_USERNAME:
-                footer_parts.append(f"| [助手BOT](https://t.me/{QA_BOT_USERNAME})")
-                footer_parts.append(f"| [投稿](https://t.me/{QA_BOT_USERNAME}?start=submit)")
+            assistant_bot_link, submission_link = self._build_qa_bot_links()
+            if assistant_bot_link:
+                footer_parts.append(f"| {assistant_bot_link}")
+                footer_parts.append(f"| {submission_link}")
 
             return " ".join(footer_parts)
 
         except Exception as e:
             logger.error(f"生成底栏失败: {type(e).__name__}: {e}", exc_info=True)
             return ""
+
+    @staticmethod
+    def _build_qa_bot_links() -> tuple[str, str]:
+        """构建 QA Bot 相关链接
+
+        Returns:
+            助手 BOT 链接和投稿链接
+        """
+        if not QA_BOT_USERNAME:
+            return "", ""
+
+        return (
+            f"[助手BOT](https://t.me/{QA_BOT_USERNAME})",
+            f"[投稿](https://t.me/{QA_BOT_USERNAME}?start=submit)",
+        )
 
     async def get_statistics(self, channel_id: str = None) -> dict[str, Any]:
         """

--- a/core/forwarding/forwarding_handler.py
+++ b/core/forwarding/forwarding_handler.py
@@ -155,7 +155,7 @@ class ForwardingHandler:
         try:
             # 从完整配置中提取转发配置
             # 如果没有 forwarding 键，使用空字典作为默认值
-            forwarding_config = copy.deepcopy(event.config.get("forwarding") or {})
+            forwarding_config = event.config.get("forwarding") or {}
 
             # 确保配置结构完整
             if "enabled" not in forwarding_config:
@@ -690,6 +690,7 @@ class ForwardingHandler:
         except ValueError as e:
             # Telethon 在 forward_messages 无法解析 from_peer 实体时会抛出 ValueError，
             # 此时改用监听客户端（通常是 UserBot）进行回退转发。
+            # 注意：这里只处理实体解析失败；网络、权限等错误交由上层转发流程统一记录。
             logger.warning(
                 f"发送客户端无法解析源频道实体，尝试使用监听客户端转发: {type(e).__name__}: {e}"
             )

--- a/core/forwarding/forwarding_handler.py
+++ b/core/forwarding/forwarding_handler.py
@@ -15,6 +15,7 @@
 """
 
 import asyncio
+import copy
 import hashlib
 import logging
 from datetime import UTC, datetime
@@ -116,7 +117,7 @@ class ForwardingHandler:
         Args:
             config: 配置字典
         """
-        self._config = config
+        self._config = copy.deepcopy(config)
         logger.info(f"转发配置已更新: {len(config.get('rules', []))} 条规则")
 
     async def on_config_updated(self, event: ConfigChangedEvent):
@@ -130,7 +131,7 @@ class ForwardingHandler:
         try:
             # 从完整配置中提取转发配置
             # 如果没有 forwarding 键，使用空字典作为默认值
-            forwarding_config = event.config.get("forwarding") or {}
+            forwarding_config = copy.deepcopy(event.config.get("forwarding") or {})
 
             # 确保配置结构完整
             if "enabled" not in forwarding_config:

--- a/core/i18n/i18n.py
+++ b/core/i18n/i18n.py
@@ -636,7 +636,7 @@ MESSAGE_ZH_CN = {
     "forwarding.footer.usage": "用法：\n\n/forwarding_footer <源频道> <目标频道> <底栏内容>\n/forwarding_footer <源频道> <目标频道> clear\n\n示例：\n/forwarding_footer https://t.me/source https://t.me/target 📢 来源: {source_title}\\n🔗 {source_link}\n/forwarding_footer https://t.me/source https://t.me/target clear",
     "forwarding.footer.invalid_params": "❌ 参数无效\n\n用法：/forwarding_footer <源频道> <目标频道> <底栏内容>\n\n或使用 clear 清除底栏",
     "forwarding.footer.not_found": "❌ 转发规则不存在\n\n源频道：{source}\n目标频道：{target}",
-    "forwarding.footer.placeholders": "支持的占位符：\n\n{source_link} - 源消息链接\n{source_title} - 源频道名称\n{target_title} - 目标频道名称\n{source_channel} - 源频道ID\n{target_channel} - 目标频道ID\n{message_id} - 消息ID",
+    "forwarding.footer.placeholders": "支持的占位符：\n\n{source_link} - 源消息链接\n{source_title} - 源频道名称\n{target_title} - 目标频道名称\n{source_channel} - 源频道ID\n{target_channel} - 目标频道ID\n{message_id} - 消息ID\n{assistant_bot} - 助手 BOT 链接\n{submission} - 投稿链接",
     "forwarding.default_footer.usage": "用法：\n\n/forwarding_default_footer on - 启用默认底栏\n/forwarding_default_footer off - 禁用默认底栏",
     # ========== 关键词白名单 ==========
     "forwarding.keywords.title": "🏷️ **关键词白名单配置**",
@@ -1384,7 +1384,7 @@ MESSAGE_EN_US = {
     "forwarding.footer.usage": "Usage:\n\n/forwarding_footer <source> <target> <footer content>\n/forwarding_footer <source> <target> clear\n\nExample:\n/forwarding_footer https://t.me/source https://t.me/target Source: {source_title}\\n{source_link}\n/forwarding_footer https://t.me/source https://t.me/target clear",
     "forwarding.footer.invalid_params": "❌ Invalid parameters\n\nUsage: /forwarding_footer <source> <target> <footer content>\n\nOr use clear to clear footer",
     "forwarding.footer.not_found": "❌ Forwarding rule not found\n\nSource: {source}\nTarget: {target}",
-    "forwarding.footer.placeholders": "Supported placeholders:\n\n{source_link} - Source message link\n{source_title} - Source channel name\n{target_title} - Target channel name\n{source_channel} - Source channel ID\n{target_channel} - Target channel ID\n{message_id} - Message ID",
+    "forwarding.footer.placeholders": "Supported placeholders:\n\n{source_link} - Source message link\n{source_title} - Source channel name\n{target_title} - Target channel name\n{source_channel} - Source channel ID\n{target_channel} - Target channel ID\n{message_id} - Message ID\n{assistant_bot} - Assistant bot link\n{submission} - Submission link",
     "forwarding.default_footer.usage": "Usage:\n\n/forwarding_default_footer on - Enable default footer\n/forwarding_default_footer off - Disable default footer",
     # ========== Keyword Whitelist ==========
     "forwarding.keywords.title": "🏷️ **Keyword Whitelist Configuration**",

--- a/core/initializers/forwarding_initializer.py
+++ b/core/initializers/forwarding_initializer.py
@@ -163,6 +163,20 @@ class ForwardingInitializer:
 
         return source_channel_ids
 
+    def _get_current_source_channels(self) -> set:
+        """获取当前生效的转发源频道ID集合
+
+        优先从 ForwardingHandler 的实时配置中读取，确保 WebUI 热重载新增的
+        转发规则无需重启即可被监听器识别。
+
+        Returns:
+            当前源频道ID集合
+        """
+        if not self.forwarding_handler:
+            return set()
+
+        return self._extract_source_channels(self.forwarding_handler.config or {})
+
     async def _register_message_listener(
         self, monitoring_client: "TelegramClient", source_channel_ids: set, is_userbot: bool
     ) -> None:
@@ -187,10 +201,17 @@ class ForwardingInitializer:
                     f"转发监听器被触发: chat_username={chat_username}, chat_id={chat_id}"
                 )
 
+                current_source_channel_ids = self._get_current_source_channels()
+                if current_source_channel_ids != source_channel_ids:
+                    self.logger.debug(
+                        f"转发源频道配置已动态更新: "
+                        f"{source_channel_ids} -> {current_source_channel_ids}"
+                    )
+
                 # 检查是否是配置的源频道
-                is_source_channel = (chat_username and chat_username in source_channel_ids) or (
-                    chat_id in source_channel_ids
-                )
+                is_source_channel = (
+                    chat_username and chat_username in current_source_channel_ids
+                ) or (chat_id in current_source_channel_ids)
 
                 if not is_source_channel:
                     self.logger.debug(f"频道 {chat_username or chat_id} 不是源频道，跳过")

--- a/core/initializers/forwarding_initializer.py
+++ b/core/initializers/forwarding_initializer.py
@@ -98,8 +98,8 @@ class ForwardingInitializer:
             if userbot and rule_count > 0:
                 await self._auto_join_channels(userbot, forwarding_config)
 
-            # 提取源频道ID
-            source_channel_ids = self._extract_source_channels(forwarding_config)
+            # 提取源频道ID（set_config 已填充处理器缓存）
+            source_channel_ids = self.forwarding_handler.source_channel_ids
             self.logger.info(f"转发功能监听的源频道: {source_channel_ids}")
 
             # 注册消息监听器（即使禁用也注册，由 enabled 标志控制是否处理）
@@ -142,26 +142,6 @@ class ForwardingInitializer:
         else:
             error_message = result.get("message", "未知错误")
             self.logger.error(f"UserBot 自动加入源频道失败: {error_message}")
-
-    def _extract_source_channels(self, forwarding_config: dict) -> set:
-        """提取所有源频道ID
-
-        Args:
-            forwarding_config: 转发配置
-
-        Returns:
-            源频道ID集合
-        """
-        source_channels = forwarding_config.get("rules", [])
-        source_channel_ids = set()
-
-        for rule in source_channels:
-            source_url = rule.get("source_channel", "")
-            if source_url:
-                channel_id = source_url.rstrip("/").split("/")[-1]
-                source_channel_ids.add(channel_id)
-
-        return source_channel_ids
 
     def _get_current_source_channels(self) -> set:
         """获取当前生效的转发源频道ID集合

--- a/core/initializers/forwarding_initializer.py
+++ b/core/initializers/forwarding_initializer.py
@@ -175,7 +175,7 @@ class ForwardingInitializer:
         if not self.forwarding_handler:
             return set()
 
-        return self._extract_source_channels(self.forwarding_handler.config or {})
+        return self.forwarding_handler.source_channel_ids
 
     async def _register_message_listener(
         self, monitoring_client: "TelegramClient", source_channel_ids: set, is_userbot: bool

--- a/core/initializers/web_api_initializer.py
+++ b/core/initializers/web_api_initializer.py
@@ -57,7 +57,8 @@ def _setup_webui_logging() -> str:
 class WebAPIInitializer:
     """WebUI API 服务器初始化器"""
 
-    def __init__(self):
+    def __init__(self, config_manager=None):
+        self._config_manager = config_manager
         self._server: Server | None = None
         self._task: asyncio.Task | None = None
 
@@ -104,7 +105,9 @@ class WebAPIInitializer:
         import uvicorn
 
         from core.web_api.app import create_app
+        from core.web_api.deps import configure_config_manager
 
+        configure_config_manager(self._config_manager)
         app = create_app()
 
         config = uvicorn.Config(

--- a/core/web_api/deps.py
+++ b/core/web_api/deps.py
@@ -14,6 +14,7 @@
 提供 FastAPI 路由的公共依赖项，如认证、数据库访问、配置管理等。
 """
 
+import asyncio
 import hashlib
 import hmac
 import inspect
@@ -32,6 +33,20 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+_config_manager: Any | None = None
+
+
+def configure_config_manager(config_manager: Any | None) -> None:
+    """配置 WebUI 使用的配置管理器
+
+    Args:
+        config_manager: 主进程 ConfigManager 实例，用于保存配置后显式触发热重载
+    """
+    global _config_manager
+    _config_manager = config_manager
+    if config_manager:
+        logger.info("WebUI 配置热重载管理器已注入")
+
 
 def get_config() -> dict:
     """获取当前配置（同步读取 config.json）"""
@@ -41,6 +56,36 @@ def get_config() -> dict:
 def write_config(config: dict) -> None:
     """保存配置（写入 config.json 并触发热更新）"""
     save_config(config)
+    _schedule_config_reload()
+
+
+def _schedule_config_reload() -> None:
+    """安排配置热重载任务
+
+    WebUI 与 Bot 共享事件循环时，保存配置后直接调用 ConfigManager.reload_config()，
+    避免仅依赖 watchdog 文件事件导致热重载延迟或遗漏。
+    """
+    if not _config_manager:
+        logger.debug("未注入配置管理器，跳过显式热重载触发")
+        return
+
+    async def _reload() -> None:
+        try:
+            success, error = await _config_manager.reload_config()
+            if success:
+                logger.info("✅ WebUI 保存配置后已触发热重载")
+            else:
+                logger.error(f"WebUI 保存配置后触发热重载失败: {error}")
+        except Exception as e:
+            logger.error(f"WebUI 配置热重载任务异常: {type(e).__name__}: {e}", exc_info=True)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.warning("当前无线程运行中的事件循环，跳过 WebUI 显式热重载触发")
+        return
+
+    loop.create_task(_reload())
 
 
 def get_database():

--- a/core/web_api/deps.py
+++ b/core/web_api/deps.py
@@ -65,13 +65,14 @@ def _schedule_config_reload() -> None:
     WebUI 与 Bot 共享事件循环时，保存配置后直接调用 ConfigManager.reload_config()，
     避免仅依赖 watchdog 文件事件导致热重载延迟或遗漏。
     """
-    if not _config_manager:
+    config_manager = _config_manager
+    if not config_manager:
         logger.debug("未注入配置管理器，跳过显式热重载触发")
         return
 
     async def _reload() -> None:
         try:
-            success, error = await _config_manager.reload_config()
+            success, error = await config_manager.reload_config()
             if success:
                 logger.info("✅ WebUI 保存配置后已触发热重载")
             else:

--- a/tests/test_config_hot_reload_forwarding.py
+++ b/tests/test_config_hot_reload_forwarding.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Sakura-Bot
+#
+# 本项目采用 GNU Affero General Public License Version 3.0 (AGPL-3.0) 许可
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from core.config.events import ConfigChangedEvent
+from core.forwarding.forwarding_handler import ForwardingHandler
+from core.initializers.forwarding_initializer import ForwardingInitializer
+from core.web_api import deps
+
+
+@pytest.mark.asyncio
+async def test_webui_write_config_schedules_config_reload():
+    """WebUI 保存配置后应显式安排配置热重载。"""
+    config_manager = SimpleNamespace(reload_config=AsyncMock(return_value=(True, "")))
+    deps.configure_config_manager(config_manager)
+
+    with patch.object(deps, "save_config") as save_config:
+        deps.write_config({"forwarding": {"enabled": True, "rules": []}})
+        await asyncio.sleep(0)
+
+    save_config.assert_called_once()
+    config_manager.reload_config.assert_awaited_once()
+    deps.configure_config_manager(None)
+
+
+@pytest.mark.asyncio
+async def test_forwarding_handler_on_config_updated_updates_runtime_config():
+    """配置事件应更新转发处理器运行时配置。"""
+    handler = ForwardingHandler(Mock(), Mock(), Mock())
+    handler.enabled = False
+    handler.set_config({"enabled": False, "rules": []})
+
+    event = ConfigChangedEvent(
+        config={
+            "forwarding": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "source_channel": "https://t.me/source_channel",
+                        "target_channel": "https://t.me/target_channel",
+                    }
+                ],
+            }
+        },
+        version=1,
+        changed_fields={"forwarding.rules"},
+    )
+
+    await handler.on_config_updated(event)
+
+    assert handler.enabled is True
+    assert len(handler.config["rules"]) == 1
+    assert handler.config["rules"][0]["source_channel"] == "https://t.me/source_channel"
+
+
+def test_forwarding_initializer_reads_current_source_channels_from_handler_config():
+    """转发监听源频道应从处理器当前配置动态读取。"""
+    initializer = ForwardingInitializer()
+    handler = SimpleNamespace(
+        config={
+            "rules": [
+                {
+                    "source_channel": "https://t.me/new_source",
+                    "target_channel": "https://t.me/target",
+                }
+            ]
+        }
+    )
+    initializer.forwarding_handler = handler
+
+    assert initializer._get_current_source_channels() == {"new_source"}
+
+    handler.config = {
+        "rules": [
+            {
+                "source_channel": "https://t.me/another_source",
+                "target_channel": "https://t.me/target",
+            }
+        ]
+    }
+
+    assert initializer._get_current_source_channels() == {"another_source"}

--- a/tests/test_config_hot_reload_forwarding.py
+++ b/tests/test_config_hot_reload_forwarding.py
@@ -3,12 +3,15 @@
 # 本项目采用 GNU Affero General Public License Version 3.0 (AGPL-3.0) 许可
 
 import asyncio
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from core.config.events import ConfigChangedEvent
+from core.config.manager import ConfigManager
 from core.forwarding.forwarding_handler import ForwardingHandler
 from core.initializers.forwarding_initializer import ForwardingInitializer
 from core.web_api import deps
@@ -26,6 +29,23 @@ async def test_webui_write_config_schedules_config_reload():
 
     save_config.assert_called_once()
     config_manager.reload_config.assert_awaited_once()
+    deps.configure_config_manager(None)
+
+
+@pytest.mark.asyncio
+async def test_webui_reload_task_uses_bound_config_manager():
+    """热重载任务应使用调度时绑定的配置管理器。"""
+    first_manager = SimpleNamespace(reload_config=AsyncMock(return_value=(True, "")))
+    second_manager = SimpleNamespace(reload_config=AsyncMock(return_value=(True, "")))
+    deps.configure_config_manager(first_manager)
+
+    with patch.object(deps, "save_config"):
+        deps.write_config({"forwarding": {"enabled": True, "rules": []}})
+        deps.configure_config_manager(second_manager)
+        await asyncio.sleep(0)
+
+    first_manager.reload_config.assert_awaited_once()
+    second_manager.reload_config.assert_not_awaited()
     deps.configure_config_manager(None)
 
 
@@ -57,13 +77,15 @@ async def test_forwarding_handler_on_config_updated_updates_runtime_config():
     assert handler.enabled is True
     assert len(handler.config["rules"]) == 1
     assert handler.config["rules"][0]["source_channel"] == "https://t.me/source_channel"
+    assert handler.source_channel_ids == {"source_channel"}
 
 
-def test_forwarding_initializer_reads_current_source_channels_from_handler_config():
-    """转发监听源频道应从处理器当前配置动态读取。"""
+def test_forwarding_initializer_reads_current_source_channels_from_handler_cache():
+    """转发监听源频道应从处理器缓存动态读取。"""
     initializer = ForwardingInitializer()
-    handler = SimpleNamespace(
-        config={
+    handler = ForwardingHandler(Mock(), Mock(), Mock())
+    handler.set_config(
+        {
             "rules": [
                 {
                     "source_channel": "https://t.me/new_source",
@@ -76,13 +98,39 @@ def test_forwarding_initializer_reads_current_source_channels_from_handler_confi
 
     assert initializer._get_current_source_channels() == {"new_source"}
 
-    handler.config = {
-        "rules": [
-            {
-                "source_channel": "https://t.me/another_source",
-                "target_channel": "https://t.me/target",
-            }
-        ]
-    }
+    handler.set_config(
+        {
+            "rules": [
+                {
+                    "source_channel": "https://t.me/another_source",
+                    "target_channel": "https://t.me/target",
+                }
+            ]
+        }
+    )
 
     assert initializer._get_current_source_channels() == {"another_source"}
+
+
+@pytest.mark.asyncio
+async def test_config_manager_reload_skips_unchanged_snapshot():
+    """配置内容未变化时应跳过重复事件发布。"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write('{"version": 1}')
+        f.flush()
+        config_file = Path(f.name)
+
+    try:
+        manager = ConfigManager(asyncio.get_running_loop())
+        assert manager.initialize_sync(config_file)[0] is True
+
+        event_bus = SimpleNamespace(publish=AsyncMock())
+        manager.event_bus = event_bus
+
+        success, error = await manager.reload_config()
+
+        assert success is True
+        assert error == ""
+        event_bus.publish.assert_not_awaited()
+    finally:
+        await asyncio.to_thread(config_file.unlink, missing_ok=True)

--- a/tests/test_config_hot_reload_forwarding.py
+++ b/tests/test_config_hot_reload_forwarding.py
@@ -115,12 +115,10 @@ def test_forwarding_initializer_reads_current_source_channels_from_handler_cache
 @pytest.mark.asyncio
 async def test_config_manager_reload_skips_unchanged_snapshot():
     """配置内容未变化时应跳过重复事件发布。"""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-        f.write('{"version": 1}')
-        f.flush()
-        config_file = Path(f.name)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_file = Path(tmpdir) / "config.json"
+        await asyncio.to_thread(config_file.write_text, '{"version": 1}', encoding="utf-8")
 
-    try:
         manager = ConfigManager(asyncio.get_running_loop())
         assert manager.initialize_sync(config_file)[0] is True
 
@@ -132,5 +130,3 @@ async def test_config_manager_reload_skips_unchanged_snapshot():
         assert success is True
         assert error == ""
         event_bus.publish.assert_not_awaited()
-    finally:
-        await asyncio.to_thread(config_file.unlink, missing_ok=True)

--- a/web/src/api/modules.ts
+++ b/web/src/api/modules.ts
@@ -412,6 +412,12 @@ export async function updateDefaultCommentWelcome(data: Record<string, unknown>)
 
 // ==================== UserBot ====================
 
+export interface UserBotChannel {
+  id: number;
+  title: string;
+  username?: string | null;
+}
+
 export async function getUserBotStatus() {
   const res = await apiClient.get("/userbot/status");
   return res.data;

--- a/web/src/views/ForwardingView.vue
+++ b/web/src/views/ForwardingView.vue
@@ -234,7 +234,7 @@ function applyFooterTemplate(value: string | null) {
 
 function insertFooterPlaceholder(placeholder: string) {
   ruleForm.custom_footer = ruleForm.custom_footer
-    ? `${ruleForm.custom_footer}${/\s$/.test(ruleForm.custom_footer) ? "" : " "}${placeholder}`
+    ? `${ruleForm.custom_footer}${ruleForm.custom_footer.endsWith(" ") ? "" : " "}${placeholder}`
     : placeholder;
 }
 

--- a/web/src/views/ForwardingView.vue
+++ b/web/src/views/ForwardingView.vue
@@ -21,10 +21,29 @@
       class="modal-responsive" positive-text="保存" negative-text="取消" @positive-click="handleSaveRule">
       <n-form label-placement="left" label-width="120">
         <n-form-item label="源频道">
-          <n-input v-model:value="ruleForm.source_channel" placeholder="https://t.me/source_channel" />
+          <n-select
+            v-model:value="ruleForm.source_channel"
+            :options="sourceChannelOptions"
+            :loading="sourceChannelsLoading"
+            clearable
+            filterable
+            tag
+            placeholder="选择 UserBot 已加入频道，或手动输入频道链接/ID"
+          />
+          <template #feedback>
+            候选项来自 UserBot 已加入频道；列表为空时可手动输入。
+          </template>
         </n-form-item>
         <n-form-item label="目标频道">
-          <n-input v-model:value="ruleForm.target_channel" placeholder="https://t.me/target_channel" />
+          <n-select
+            v-model:value="ruleForm.target_channel"
+            :options="targetChannelOptions"
+            :loading="targetChannelsLoading"
+            clearable
+            filterable
+            tag
+            placeholder="选择机器人管理频道，或手动输入频道链接/ID"
+          />
         </n-form-item>
         <n-form-item label="复制模式">
           <n-switch v-model:value="ruleForm.copy_mode" />
@@ -35,9 +54,56 @@
         <n-form-item label="黑名单">
           <n-dynamic-tags v-model:value="ruleForm.blacklist" />
         </n-form-item>
+        <n-form-item label="页脚模板">
+          <n-select
+            :options="footerTemplateOptions"
+            clearable
+            placeholder="选择模板并填入自定义页脚"
+            @update:value="applyFooterTemplate"
+          />
+          <template #feedback>
+            留空自定义页脚将使用全局默认底栏；模板可继续手动编辑。
+          </template>
+        </n-form-item>
         <n-form-item label="自定义页脚">
-          <n-input v-model:value="ruleForm.custom_footer" type="textarea" :rows="2"
-            placeholder="📢 来源: {source_title}\n🔗 {source_link}" />
+          <n-input
+            v-model:value="ruleForm.custom_footer"
+            type="textarea"
+            :rows="3"
+            :placeholder="defaultFooterTemplate"
+          />
+        </n-form-item>
+        <n-form-item label="占位符">
+          <n-space size="small" vertical>
+            <n-space size="small">
+              <n-tag
+                v-for="placeholder in footerPlaceholders"
+                :key="placeholder.value"
+                size="small"
+                class="cursor-pointer"
+                @click="insertFooterPlaceholder(placeholder.value)"
+              >
+                {{ placeholder.value }}
+              </n-tag>
+            </n-space>
+            <n-text depth="3" class="placeholder-help">
+              点击可追加到自定义页脚：
+              <span v-for="placeholder in footerPlaceholders" :key="placeholder.value">
+                {{ placeholder.value }} = {{ placeholder.description }}；
+              </span>
+            </n-text>
+          </n-space>
+        </n-form-item>
+        <n-form-item label="快捷说明">
+          <n-space size="small">
+            <n-tag
+              v-for="placeholder in footerPlaceholders"
+              :key="`${placeholder.value}-desc`"
+              size="small"
+            >
+              {{ placeholder.value }}：{{ placeholder.description }}
+            </n-tag>
+          </n-space>
         </n-form-item>
       </n-form>
     </n-modal>
@@ -51,12 +117,19 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, onMounted, h } from "vue";
+import { ref, reactive, computed, onMounted, h } from "vue";
 import { NButton, NTag, NSpace, useMessage } from "naive-ui";
-import type { DataTableColumns } from "naive-ui";
+import type { DataTableColumns, SelectOption } from "naive-ui";
 import {
-  getForwardingConfig, toggleForwarding, addForwardingRule,
-  updateForwardingRule, deleteForwardingRule,
+  addForwardingRule,
+  deleteForwardingRule,
+  getChannels,
+  getForwardingConfig,
+  toggleForwarding,
+  updateForwardingRule,
+  userBotListChannels,
+  type ChannelInfo,
+  type UserBotChannel,
 } from "@/api/modules";
 import { getChannelName } from "@/utils/formatters";
 
@@ -68,6 +141,10 @@ const showModal = ref(false);
 const showDeleteModal = ref(false);
 const editingIndex = ref(-1);
 const deleteIndex = ref(-1);
+const sourceChannelsLoading = ref(false);
+const targetChannelsLoading = ref(false);
+const userbotChannels = ref<UserBotChannel[]>([]);
+const targetChannels = ref<string[]>([]);
 
 const ruleForm = reactive({
   source_channel: "",
@@ -77,6 +154,97 @@ const ruleForm = reactive({
   blacklist: [] as string[],
   custom_footer: "",
 });
+
+const footerTemplates = [
+  {
+    label: "全局默认",
+    value: "[Source]({source_link}) {target_channel}\n🌸[助推](https://t.me/boost/{target_channel}) | {assistant_bot} | {submission}",
+  },
+  {
+    label: "简洁来源",
+    value: "📢 来源: {source_title}\n🔗 {source_link}",
+  },
+  {
+    label: "频道署名",
+    value: "Source: {source_title} | {source_link}",
+  },
+  {
+    label: "完整信息",
+    value: "📌 来源频道: {source_title}\n🎯 目标频道: {target_title}\n🆔 消息 ID: {message_id}\n🔗 原文: {source_link}",
+  },
+  {
+    label: "仅原文链接",
+    value: "🔗 {source_link}",
+  },
+  {
+    label: "清空自定义页脚",
+    value: "",
+  },
+];
+
+const defaultFooterTemplate = footerTemplates[0].value;
+
+const footerTemplateOptions = footerTemplates.map((template) => ({
+  label: template.label,
+  value: template.value,
+}));
+
+const footerPlaceholders = [
+  { value: "{source_link}", description: "源消息链接" },
+  { value: "{source_title}", description: "源频道名称" },
+  { value: "{target_title}", description: "目标频道名称" },
+  { value: "{source_channel}", description: "源频道 ID" },
+  { value: "{target_channel}", description: "目标频道用户名或 ID" },
+  { value: "{message_id}", description: "消息 ID" },
+  { value: "{assistant_bot}", description: "助手 BOT 链接" },
+  { value: "{submission}", description: "投稿链接" },
+];
+
+const sourceChannelOptions = computed<SelectOption[]>(() => {
+  const options = userbotChannels.value.map((channel) => {
+    const value = getUserBotChannelValue(channel);
+    const label = channel.username
+      ? `${channel.title} (@${channel.username})`
+      : `${channel.title} (ID: ${channel.id})`;
+
+    return { label, value };
+  });
+
+  return dedupeOptions(options);
+});
+
+const targetChannelOptions = computed<SelectOption[]>(() =>
+  dedupeOptions(targetChannels.value.map((channel) => ({
+    label: getChannelName(channel),
+    value: channel,
+  })))
+);
+
+function getUserBotChannelValue(channel: UserBotChannel) {
+  if (channel.username) return `https://t.me/${channel.username}`;
+  return `-100${channel.id}`;
+}
+
+function dedupeOptions(options: SelectOption[]) {
+  const seen = new Set<string>();
+  return options.filter((option) => {
+    const value = String(option.value || "");
+    if (!value || seen.has(value)) return false;
+    seen.add(value);
+    return true;
+  });
+}
+
+function applyFooterTemplate(value: string | null) {
+  if (value === null) return;
+  ruleForm.custom_footer = value;
+}
+
+function insertFooterPlaceholder(placeholder: string) {
+  ruleForm.custom_footer = ruleForm.custom_footer
+    ? `${ruleForm.custom_footer}${placeholder}`
+    : placeholder;
+}
 
 const columns: DataTableColumns = [
   { title: "#", key: "index", width: 50, render: (_, i) => i + 1 },
@@ -139,6 +307,11 @@ async function handleToggle(enabled: boolean) {
 }
 
 async function handleSaveRule() {
+  if (!ruleForm.source_channel.trim() || !ruleForm.target_channel.trim()) {
+    message.warning("请选择或输入源频道和目标频道");
+    return false;
+  }
+
   try {
     const data = { ...ruleForm, patterns: [], blacklist_patterns: [], forward_original_only: false };
     let res;
@@ -183,5 +356,37 @@ async function loadData() {
   }
 }
 
-onMounted(loadData);
+async function loadSourceChannels() {
+  sourceChannelsLoading.value = true;
+  try {
+    const res = await userBotListChannels();
+    if (res.success) {
+      userbotChannels.value = res.channels || [];
+    } else if (res.message) {
+      message.warning(`UserBot 频道列表不可用：${res.message}`);
+    }
+  } catch {
+    message.warning("加载 UserBot 已加入频道失败，可手动输入源频道");
+  } finally {
+    sourceChannelsLoading.value = false;
+  }
+}
+
+async function loadTargetChannels() {
+  targetChannelsLoading.value = true;
+  try {
+    const res = await getChannels();
+    if (res.success) {
+      targetChannels.value = (res.data.channels || []).map((channel: ChannelInfo) => channel.url);
+    }
+  } catch {
+    message.warning("加载目标频道列表失败，可手动输入目标频道");
+  } finally {
+    targetChannelsLoading.value = false;
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([loadData(), loadSourceChannels(), loadTargetChannels()]);
+});
 </script>

--- a/web/src/views/ForwardingView.vue
+++ b/web/src/views/ForwardingView.vue
@@ -76,33 +76,25 @@
         <n-form-item label="占位符">
           <n-space size="small" vertical>
             <n-space size="small">
-              <n-tag
+              <n-tooltip
                 v-for="placeholder in footerPlaceholders"
                 :key="placeholder.value"
-                size="small"
-                class="cursor-pointer"
-                @click="insertFooterPlaceholder(placeholder.value)"
               >
-                {{ placeholder.value }}
-              </n-tag>
+                <template #trigger>
+                  <n-tag
+                    size="small"
+                    class="cursor-pointer"
+                    @click="insertFooterPlaceholder(placeholder.value)"
+                  >
+                    {{ placeholder.value }}
+                  </n-tag>
+                </template>
+                {{ placeholder.description }}
+              </n-tooltip>
             </n-space>
             <n-text depth="3" class="placeholder-help">
-              点击可追加到自定义页脚：
-              <span v-for="placeholder in footerPlaceholders" :key="placeholder.value">
-                {{ placeholder.value }} = {{ placeholder.description }}；
-              </span>
+              点击标签可追加到自定义页脚，悬停查看说明。
             </n-text>
-          </n-space>
-        </n-form-item>
-        <n-form-item label="快捷说明">
-          <n-space size="small">
-            <n-tag
-              v-for="placeholder in footerPlaceholders"
-              :key="`${placeholder.value}-desc`"
-              size="small"
-            >
-              {{ placeholder.value }}：{{ placeholder.description }}
-            </n-tag>
           </n-space>
         </n-form-item>
       </n-form>
@@ -118,7 +110,7 @@
 
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted, h } from "vue";
-import { NButton, NTag, NSpace, useMessage } from "naive-ui";
+import { NButton, NTag, NSpace, NTooltip, useMessage } from "naive-ui";
 import type { DataTableColumns, SelectOption } from "naive-ui";
 import {
   addForwardingRule,
@@ -242,7 +234,7 @@ function applyFooterTemplate(value: string | null) {
 
 function insertFooterPlaceholder(placeholder: string) {
   ruleForm.custom_footer = ruleForm.custom_footer
-    ? `${ruleForm.custom_footer}${placeholder}`
+    ? `${ruleForm.custom_footer}${/\s$/.test(ruleForm.custom_footer) ? "" : " "}${placeholder}`
     : placeholder;
 }
 


### PR DESCRIPTION
Implement fallback forwarding for message handling and enhance the configuration management by enabling explicit hot reload after saving changes. Introduce new placeholders for custom footer generation and update internationalization strings accordingly.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 在前期 `+429/-23` 变更（引入回退转发与配置保存时显式热重载）的基础上，**进一步优化热重载去重逻辑并重构配置管理**，最终净增 `+516/-44` 行（共 11 个文件）。整体聚焦于提升转发模块的稳定性与配置生效的实时性。

### 主要改动列表
- **热重载去重与重构**：优化转发处理器的重载逻辑，避免重复触发（`forwarding_handler.py` +2/-1）。
- **配置管理精简**：移除转发初始化器中的冗余配置赋值，改用统一设置方法（具体文件 `forwarding_initializer.py` 调整，整体该模块净变更 +2/-22）。
- **测试同步更新**：调整热重载相关测试用例，适配新的重载与配置逻辑（如 `test_config_hot_reload_forwarding.py` +3/-7）。
- **前端交互微调**：简化转发视图中的保存交互，使回退转发设置的实时反馈更流畅（如 `ForwardingView.vue` +1/-1）。

### 影响范围
- **核心转发能力**：回退转发与规则匹配更稳定，配置保存后立即生效，无需重启服务。
- **配置状态一致性**：减少冗余赋值，降低配置与运行时状态不一致的风险。
- **用户交互体验**：前端保存操作更流畅，回退转发设置能实时反馈。
- **测试覆盖**：热重载去重逻辑获得更精准的自动化验证。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    manager["core/config/manager.py"]
    forwarding_handler["core/forwarding/forwarding_handler.py"]
    forwarding_initializer["core/initializers/forwarding_initializer.py"]
    deps["core/web_api/deps.py"]
    test["tests/test_config_hot_reload_forwarding.py"]

    test --> manager
    test --> forwarding_handler
    test --> forwarding_initializer
    test --> deps

    forwarding_initializer --> manager
    forwarding_initializer --> forwarding_handler

    forwarding_handler -.-> manager
    deps -.-> manager
```

<!-- sakura-ai-depgraph-end -->